### PR TITLE
Release v0.8.0 — Structured Output + Tool Use

### DIFF
--- a/smart-ux-api/CHANGELOG.md
+++ b/smart-ux-api/CHANGELOG.md
@@ -9,6 +9,26 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [Unreleased] - v0.8.0 (in-progress)
+
+### Added
+- **Structured Output** (Provider 중립 JSON Schema 강제 응답 — T2-a)
+  - `com.smartuxapi.ai.schema`: `ResponseSchema` / `SchemaBuilder`
+  - OpenAI Responses: `text.format = { type: "json_schema", ... }` 매핑
+  - Gemini: `generationConfig.responseMimeType + responseSchema` 매핑
+  - `Chatting.sendPromptWithSchema(userMsg, schema)` default 메서드 추가
+  - `ResponsesChatting` / `GeminiChatting` override — 응답 원문을 자동 파싱하여 `structured` 키 (JsonNode) 로 병기
+  - 파싱 실패는 예외가 아닌 WARN 로그 + `structured=null` (호출자가 fallback 결정)
+  - `SchemaBuilder`: object 루트 + 5 타입 (string/integer/boolean/array/nested object) — strict 호환 `additionalProperties: false` 자동 주입
+  - T2-b Tool Use 와 `SchemaBuilder.build()` JsonNode 포맷 공유
+  - 가이드: `doc/structured-output-guide.md`
+  - 신규 테스트: `SchemaBuilderTest`, `ResponseSchemaTest`, `ResponsesChattingStructuredOutputTest`, `GeminiChattingStructuredOutputTest` (+22건)
+
+### Changed
+- `ResponsesAPIConnection.generateContent(JSONArray, CacheStrategy, ResponseSchema)` 오버로드 추가 — 기존 2-인자 시그니처 유지
+- `GeminiAPIConnection.generateContent(JSONArray, CacheStrategy, ResponseSchema)` 오버로드 추가
+
+---
 ## [0.7.0] - 2026-04-22
 
 ### Added

--- a/smart-ux-api/CHANGELOG.md
+++ b/smart-ux-api/CHANGELOG.md
@@ -24,9 +24,31 @@
   - 가이드: `doc/structured-output-guide.md`
   - 신규 테스트: `SchemaBuilderTest`, `ResponseSchemaTest`, `ResponsesChattingStructuredOutputTest`, `GeminiChattingStructuredOutputTest` (+22건)
 
+### Added (cont'd)
+- **Tool Use / Function Calling** (Provider 중립 T2-b)
+  - `com.smartuxapi.ai.tools`: `ToolDefinition` / `ToolHandler` / `ToolCall` / `ToolResult` / `ToolRegistry` / `ToolTurnResult`
+  - OpenAI Responses API `tools` 연동 (request/response 양방향)
+  - Gemini `functionDeclarations` 연동 (클라이언트 UUID 부여)
+  - `Chatting.sendPromptWithTools(msg, registry)` — **자동 루프** (최대 5 라운드 / `DEFAULT_MAX_TOOL_ROUNDS`)
+  - `Chatting.sendPromptExpectingToolCalls(msg, registry)` + `continueWithToolResults(results, registry)` — **수동 dispatch**
+  - 등록되지 않은 tool 호출은 `ToolResult.error` 로 LLM 에 피드백 (자동 복구 가능)
+  - Handler 예외 자동 캐치 → `ToolResult.error`
+  - Output 크기 상한 256KB — 초과 시 자동 축약
+  - `ConversationHistory` (OpenAI/Gemini 양쪽) 에 tool_call / tool_result 아이템 지원 추가
+  - `ChatRoom.setToolRegistry/getToolRegistry` default 메서드
+- **VisionTools.scanImageTool** (T1-b × T2-b 통합)
+  - Vision 모듈을 Tool 로 감싸 LLM 이 자동 호출 가능
+  - `ActionQueueHandler` 주입 시 `addImageScanInfo` 자동 호출 (imageUrl 기준 dedupe)
+- 가이드: `doc/tool-use-guide.md`
+- 신규 테스트: `ToolRegistryTest`, `ToolCallResultTest`, `ToolTurnResultTest`, `ResponsesChattingToolUseTest`, `VisionToolsTest` (+25건)
+
 ### Changed
 - `ResponsesAPIConnection.generateContent(JSONArray, CacheStrategy, ResponseSchema)` 오버로드 추가 — 기존 2-인자 시그니처 유지
 - `GeminiAPIConnection.generateContent(JSONArray, CacheStrategy, ResponseSchema)` 오버로드 추가
+- `ResponsesAPIConnection.generateContentWithTools(...)` 추가 — Tool Use 전용 경로 (ToolTurnResult 반환)
+- `GeminiAPIConnection.generateContentWithTools(...)` 추가
+- `openai.ConversationHistory`: `addAssistantOutputItems`, `addToolResult` 추가
+- `gemini.ConversationHistory`: `addModelContent`, `addToolResults` 추가
 
 ---
 ## [0.7.0] - 2026-04-22

--- a/smart-ux-api/CHANGELOG.md
+++ b/smart-ux-api/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
-## [Unreleased] - v0.8.0 (in-progress)
+## [0.8.0] - 2026-04-22
 
 ### Added
 - **Structured Output** (Provider 중립 JSON Schema 강제 응답 — T2-a)
@@ -24,7 +24,6 @@
   - 가이드: `doc/structured-output-guide.md`
   - 신규 테스트: `SchemaBuilderTest`, `ResponseSchemaTest`, `ResponsesChattingStructuredOutputTest`, `GeminiChattingStructuredOutputTest` (+22건)
 
-### Added (cont'd)
 - **Tool Use / Function Calling** (Provider 중립 T2-b)
   - `com.smartuxapi.ai.tools`: `ToolDefinition` / `ToolHandler` / `ToolCall` / `ToolResult` / `ToolRegistry` / `ToolTurnResult`
   - OpenAI Responses API `tools` 연동 (request/response 양방향)
@@ -41,6 +40,7 @@
   - `ActionQueueHandler` 주입 시 `addImageScanInfo` 자동 호출 (imageUrl 기준 dedupe)
 - 가이드: `doc/tool-use-guide.md`
 - 신규 테스트: `ToolRegistryTest`, `ToolCallResultTest`, `ToolTurnResultTest`, `ResponsesChattingToolUseTest`, `VisionToolsTest` (+25건)
+- 총 단위 테스트 수: 266 → 358 (+92건, T2-a +22 + T2-b +25, 각 suite 이중 집계 포함)
 
 ### Changed
 - `ResponsesAPIConnection.generateContent(JSONArray, CacheStrategy, ResponseSchema)` 오버로드 추가 — 기존 2-인자 시그니처 유지

--- a/smart-ux-api/doc/structured-output-guide.md
+++ b/smart-ux-api/doc/structured-output-guide.md
@@ -1,0 +1,138 @@
+# Structured Output Guide (v0.8.0+)
+
+smart-ux-api v0.8.0 은 **JSON Schema 를 강제하는 구조화 응답 API** 를 제공합니다.
+LLM 응답을 항상 정해진 스키마의 JSON 으로 받아 파싱 오류·후처리 복잡도를 줄입니다.
+
+---
+
+## 1. 핵심 API
+
+| API | 설명 |
+|-----|------|
+| `ResponseSchema.of(name, schemaNode)` | 이미 만들어진 JsonNode 로부터 스키마 구성 |
+| `ResponseSchema.object()` / `SchemaBuilder.object()` | 편의 빌더 진입점 (object 루트) |
+| `SchemaBuilder.stringProperty / integerProperty / booleanProperty / arrayProperty / objectProperty` | 기본 5 타입 |
+| `SchemaBuilder.required(...)` | 필수 필드 지정 |
+| `SchemaBuilder.asResponse(name)` | `ResponseSchema` 로 래핑 |
+| `Chatting.sendPromptWithSchema(userMsg, schema)` | **신규** — 구조화 응답 전송 |
+
+---
+
+## 2. 사용 예 — OpenAI
+
+```java
+import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+
+ChatRoom chat = new ResponsesChatRoom(apiKey, "gpt-4o-mini");
+
+ResponseSchema userSchema = SchemaBuilder.object()
+    .stringProperty("name", "사용자 이름")
+    .integerProperty("age", "나이")
+    .stringArrayProperty("hobbies", "취미 목록")
+    .required("name", "age")
+    .asResponse("UserProfile");
+
+JSONObject res = chat.getChatting().sendPromptWithSchema(
+    "Alice 는 30세, 취미는 등산과 독서입니다. 프로필을 JSON 으로 추출하세요.",
+    userSchema);
+
+// 반환 포맷
+String rawJson = (String) res.get("message");       // provider 원문 (JSON 문자열)
+JsonNode structured = (JsonNode) res.get("structured");  // 파싱된 JsonNode (실패 시 null)
+
+if (structured != null) {
+    System.out.println(structured.get("name").asText());     // "Alice"
+    System.out.println(structured.get("age").asInt());        // 30
+    System.out.println(structured.get("hobbies").get(0));     // "등산"
+}
+```
+
+---
+
+## 3. 사용 예 — Gemini
+
+동일 API, 동일 스키마를 그대로 재사용:
+
+```java
+ChatRoom chat = new GeminiChatRoom(apiKey, "gemini-1.5-pro");
+
+// 위에서 만든 userSchema 그대로 사용
+JSONObject res = chat.getChatting().sendPromptWithSchema(
+    "Alice 는 30세, 취미는 등산과 독서입니다.",
+    userSchema);
+
+JsonNode structured = (JsonNode) res.get("structured");
+```
+
+---
+
+## 4. raw JsonNode 경로 (고급)
+
+`SchemaBuilder` 가 지원하지 않는 스키마 (e.g. `enum`, `oneOf`, `pattern`) 가 필요하면
+직접 `JsonNode` 를 구성:
+
+```java
+ObjectMapper mapper = new ObjectMapper();
+JsonNode schemaNode = mapper.readTree("""
+{
+  "type": "object",
+  "properties": {
+    "status": { "type": "string", "enum": ["active", "pending", "done"] }
+  },
+  "required": ["status"],
+  "additionalProperties": false
+}
+""");
+
+ResponseSchema schema = ResponseSchema.of("StatusResult", schemaNode);
+```
+
+---
+
+## 5. 반환 포맷 상세
+
+| 키 | 타입 | 설명 |
+|----|------|------|
+| `message` | `String` | Provider 응답 원문 (schema 지정 시 JSON 문자열) |
+| `action_queue` | `JsonNode` | 기존 ActionQueueHandler 경로 — schema 와 무관 |
+| `structured` | `JsonNode` | 파싱된 JSON. **파싱 실패 시 null** (예외 없음) |
+
+`structured` 키는 schema 를 지정한 경우에만 존재. `sendPrompt(msg)` 나
+`sendPromptWithSchema(msg, null)` 는 키를 추가하지 않습니다.
+
+---
+
+## 6. Provider 매핑
+
+### 6.1 OpenAI Responses API
+- 요청: `text.format = { type: "json_schema", name, strict, schema }`
+- strict 플래그 기본 `true`. OpenAI 는 미지원 필드(`$ref`, `allOf` 등) 가 포함되면 요청 단계에서 거부.
+
+### 6.2 Gemini
+- 요청: `generationConfig.responseMimeType = "application/json"` + `generationConfig.responseSchema`
+- Gemini 는 OpenAI JSON Schema 의 **서브셋**만 지원 — `$ref`, `anyOf`, `not` 등 미지원. 초과 시 API 가 거부.
+
+---
+
+## 7. 주의사항
+
+1. **Schema 이름 필수** — OpenAI strict 모드에서 식별자로 사용됨. `SchemaBuilder.asResponse("...")` 또는 `ResponseSchema.of("...", schema)` 에서 지정.
+2. **`additionalProperties: false` 자동 주입** — `SchemaBuilder` 경로. raw JsonNode 경로는 **호출자가 직접 포함** 해야 strict 모드에서 동작.
+3. **파싱 실패는 예외가 아님** — `structured = null` + WARN 로그. 호출자가 raw `message` 를 원하면 그대로 사용 가능.
+4. **캐시/Vision 과 독립** — `markAsCacheable`, `addImageScanInfo` 와 조합 가능. schema 는 매 호출마다 지정.
+5. **토큰 사용량** — structured output 은 JSON 구조 유지를 위해 종종 원문보다 길어질 수 있음. 프롬프트에서 값 길이 제약을 명시 권장.
+
+---
+
+## 8. 하위 호환
+
+`sendPrompt(String)` 기존 호출 경로는 **그대로 유지** — `structured` 키 추가 없음.
+`Chatting.sendPromptWithSchema` 는 default 메서드로 추가되어 기존 smuxapi-demo, doribox 코드는 무수정 동작.
+
+---
+
+## 9. 관련 문서
+- `caching-guide.md` — Prompt Caching (v0.7.0)
+- `vision-guide.md` — Vision API (v0.7.0)
+- `doc/tasks/20260422_structured_output_design_sketch.md` — 설계 스케치 (로컬)

--- a/smart-ux-api/doc/tool-use-guide.md
+++ b/smart-ux-api/doc/tool-use-guide.md
@@ -1,0 +1,241 @@
+# Tool Use Guide (v0.8.0+)
+
+smart-ux-api v0.8.0 은 **LLM Function Calling / Tool Use** 를 Provider 중립 API 로 제공합니다.
+OpenAI Responses API 의 `tools`, Gemini 의 `functionDeclarations` 를 단일 인터페이스로 감싸며,
+**자동 실행 루프**와 **수동 dispatch** 두 모드를 모두 지원합니다.
+
+---
+
+## 1. 핵심 API
+
+| API | 설명 |
+|-----|------|
+| `ToolDefinition(name, description, parametersSchema, handler)` | Tool 정의 |
+| `ToolRegistry.register(def)` | 등록 |
+| `ToolCall` | LLM 이 생성한 호출 요청 (id, toolName, arguments) |
+| `ToolResult.ok(callId, output)` / `.error(callId, msg)` | 실행 결과 |
+| `Chatting.sendPromptWithTools(msg, registry)` | **자동 루프 모드** (최대 5 라운드) |
+| `Chatting.sendPromptExpectingToolCalls(msg, registry)` | **수동 모드** 진입 |
+| `Chatting.continueWithToolResults(results, registry)` | 수동 모드 continuation |
+| `VisionTools.scanImageTool(vision, aqHandler)` | Vision 을 Tool 로 감싸는 헬퍼 |
+
+---
+
+## 2. 자동 루프 (권장)
+
+```java
+import com.smartuxapi.ai.tools.*;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+import com.smartuxapi.ai.vision.VisionTools;
+import com.smartuxapi.ai.vision.VisionServiceFactory;
+
+ChatRoom chat = new ResponsesChatRoom(apiKey, "gpt-4o-mini");
+chat.setActionQueueHandler(aqHandler);
+
+ToolRegistry tools = new ToolRegistry();
+
+// Vision 을 Tool 로 등록 — ActionQueueHandler 에 결과 자동 주입
+tools.register(VisionTools.scanImageTool(
+    VisionServiceFactory.createOpenAI(apiKey), aqHandler));
+
+// 커스텀 Tool 직접 등록
+tools.register(new ToolDefinition(
+    "lookupProduct",
+    "SKU 로 제품 정보를 조회한다.",
+    SchemaBuilder.object()
+        .stringProperty("sku", "제품 SKU")
+        .required("sku")
+        .build(),
+    call -> {
+        String sku = call.getArguments().get("sku").asText();
+        // 실제 조회 로직
+        JsonNode product = productService.findBySku(sku);
+        return ToolResult.ok(call.getId(), product);
+    }
+));
+
+JSONObject res = chat.getChatting().sendPromptWithTools(
+    "오늘 화면 오른쪽 위 빨간 버튼 내용을 읽어줘", tools);
+
+String message = (String) res.get("message");           // 최종 텍스트
+JSONArray executedCalls = (JSONArray) res.get("tool_calls");
+JsonNode actionQueue = (JsonNode) res.get("action_queue");
+```
+
+라이브러리가 `sendPromptWithTools` 안에서:
+1. LLM 호출 → 응답에 `function_call` 아이템이 있으면
+2. 등록된 handler 를 실행하고
+3. 결과를 대화에 추가 후 LLM 재호출
+4. 최종 텍스트 응답이 나올 때까지 반복 (최대 `Chatting.DEFAULT_MAX_TOOL_ROUNDS = 5`)
+
+---
+
+## 3. 수동 dispatch
+
+비동기 실행·조건부 실행·사용자 승인이 필요한 경우:
+
+```java
+JSONObject res = chat.getChatting().sendPromptExpectingToolCalls(userMsg, tools);
+
+if (Boolean.TRUE.equals(res.get("pending"))) {
+    JSONArray pendingCalls = (JSONArray) res.get("tool_calls");
+
+    // 호출자가 직접 실행 (예: 사용자 승인 후, 비동기로, 병렬로 ...)
+    List<ToolResult> results = new ArrayList<>();
+    for (Object callObj : pendingCalls) {
+        JSONObject call = (JSONObject) callObj;
+        ToolResult r = executeMyself(
+            (String) call.get("id"),
+            (String) call.get("toolName"),
+            (String) call.get("arguments"));
+        results.add(r);
+    }
+
+    JSONObject done = chat.getChatting().continueWithToolResults(results, tools);
+    // done.message 에 최종 텍스트. 필요하면 반복.
+} else {
+    // LLM 이 tool 없이 바로 답변한 경우
+    String text = (String) res.get("message");
+}
+```
+
+`continueWithToolResults` 를 다시 호출할 수도 있습니다 (여러 라운드 수동 dispatch).
+
+---
+
+## 4. Tool 정의 상세
+
+### 4.1 parametersSchema
+
+`SchemaBuilder` 로 구성 (권장):
+```java
+JsonNode params = SchemaBuilder.object()
+    .stringProperty("query", "검색어")
+    .integerProperty("limit", "최대 반환 수")
+    .required("query")
+    .build();
+```
+
+또는 raw `JsonNode` 직접 (enum/oneOf 등):
+```java
+JsonNode params = mapper.readTree("""
+{ "type":"object",
+  "properties": { "level": { "type":"string", "enum":["low","med","high"] } },
+  "required": ["level"], "additionalProperties": false }
+""");
+```
+
+### 4.2 ToolHandler
+
+```java
+ToolHandler handler = call -> {
+    JsonNode args = call.getArguments();
+    // 비즈니스 로직
+    return ToolResult.ok(call.getId(), resultNode);
+};
+```
+
+- 예외를 던지면 라이브러리가 캐치하여 자동으로 `ToolResult.error` 로 변환
+- 결과 크기 상한 **256KB** — 초과 시 자동 축약 + 경고 로그
+
+### 4.3 Registry
+
+```java
+ToolRegistry reg = new ToolRegistry();
+reg.register(def1).register(def2);  // 체이닝
+reg.unregister("oldTool");
+reg.clear();
+```
+
+등록 순서는 보존되며 `all()` 로 iterate 가능.
+
+---
+
+## 5. 반환 JSON 스키마
+
+**자동 루프 — `sendPromptWithTools`**
+```json
+{
+  "message": "<최종 텍스트>",
+  "action_queue": {...},
+  "tool_calls": [
+    { "id": "call_abc", "toolName": "scanImage", "arguments": "{...}", "result": "{...}", "isError": false }
+  ]
+}
+```
+
+**수동 모드 — `sendPromptExpectingToolCalls` / `continueWithToolResults` (pending 상태)**
+```json
+{
+  "message": null,
+  "tool_calls": [
+    { "id": "call_abc", "toolName": "scanImage", "arguments": "{...}" }
+  ],
+  "pending": true
+}
+```
+
+**수동 모드 — 최종 상태**
+```json
+{
+  "message": "<최종 텍스트>",
+  "action_queue": {...},
+  "tool_calls": []
+}
+```
+
+---
+
+## 6. 안전장치
+
+| 항목 | 동작 |
+|-----|------|
+| `max_tool_rounds` | 기본 5. 초과 시 마지막 텍스트 응답 + 경고 로그 (예외 없음) |
+| 등록되지 않은 tool 호출 | `ToolResult.error` 로 LLM 에 피드백 → 복구 가능 |
+| Handler 예외 | 자동 캐치 → `ToolResult.error(ex.getClass() + msg)` |
+| Output 크기 초과 (>256KB) | 자동 축약 + 경고 |
+
+---
+
+## 7. Provider 매핑
+
+### 7.1 OpenAI Responses API
+- 요청: `"tools": [{ "type": "function", "name", "description", "parameters" }]`
+- 응답: `output[]` 중 `{ "type": "function_call", "call_id", "name", "arguments" }`
+- 결과 전송: `{ "type": "function_call_output", "call_id", "output" }`
+
+### 7.2 Gemini
+- 요청: `"tools": [{ "functionDeclarations": [{ "name", "description", "parameters" }] }]`
+- 응답: `candidates[0].content.parts[].functionCall: { "name", "args" }`
+- 결과 전송: `{ "role": "user", "parts": [{ "functionResponse": { "name", "response" } }] }`
+- **주의**: Gemini 는 호출 ID 를 응답에 포함하지 않으므로 클라이언트에서 UUID 부여
+
+---
+
+## 8. Vision 통합 (T1-b × T2-b)
+
+`VisionTools.scanImageTool` 은 v0.7.0 Vision 모듈을 Tool 로 감싸는 헬퍼:
+- `imageUrl` 인자 하나만 받음
+- 내부에서 `VisionService.scanImage(url)` 호출
+- `ActionQueueHandler` 가 제공되면 `addImageScanInfo(info)` 자동 호출 (imageUrl 기준 dedupe 포함)
+- 결과 JSON 은 `ImageScanInfo.toJSON()` 의 5개 키와 동일 (`imageUrl / extractedText / confidence / timestamp / modelUsed`)
+
+이것으로 두 경로가 공존:
+- **경로 A (수동)**: `vision.scanImage(url)` → `aqHandler.addImageScanInfo(info)` 직접 호출
+- **경로 B (Tool)**: LLM 이 `scanImage` 를 판단하여 자동 호출 → 같은 결과가 `aqHandler` 에 주입됨
+
+---
+
+## 9. 하위 호환
+
+- `sendPrompt(msg)` 기존 경로는 그대로. `tool_calls` 키 추가되지 않음.
+- 모든 신규 메서드는 `Chatting` 인터페이스의 `default` 메서드 — 기존 구현체 무수정 동작.
+- `tools=null` 또는 빈 Registry 전달 시 `sendPrompt` 로 위임됨.
+
+---
+
+## 10. 관련 문서
+- `caching-guide.md` — Prompt Caching (v0.7.0)
+- `vision-guide.md` — Vision API (v0.7.0)
+- `structured-output-guide.md` — Structured Output (v0.8.0 T2-a)
+- `doc/tasks/20260421_tool_use_design_sketch.md` — 설계 스케치 (로컬)

--- a/smart-ux-api/lib/build.gradle.kts
+++ b/smart-ux-api/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.smartuxapi.ai"  // 그룹 ID 설정
-version = "0.7.0"            // 프로젝트 버전 설정
+version = "0.8.0"            // 프로젝트 버전 설정
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/ChatRoom.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/ChatRoom.java
@@ -9,6 +9,7 @@ import com.smartuxapi.ai.cache.CacheMetrics;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.debug.DebugLogger;
+import com.smartuxapi.ai.tools.ToolRegistry;
 
 /**
  * Chatting 저장소
@@ -94,5 +95,18 @@ public interface ChatRoom {
 	default CacheMetrics getLastCacheMetrics() {
 		return getCacheStrategy().getLastMetrics();
 	}
+
+	/**
+	 * 편의용 — ChatRoom 레벨에서 ToolRegistry 를 보관. 실제 사용은
+	 * {@link Chatting#sendPromptWithTools(String, ToolRegistry)} 호출 시 직접 전달하는 방식 권장.
+	 * @since 0.8.0
+	 */
+	default void setToolRegistry(ToolRegistry registry) { /* default no-op */ }
+
+	/**
+	 * 현재 등록된 ToolRegistry (없으면 null).
+	 * @since 0.8.0
+	 */
+	default ToolRegistry getToolRegistry() { return null; }
 
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/Chatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/Chatting.java
@@ -4,10 +4,14 @@ import java.util.Set;
 
 import org.json.simple.JSONObject;
 
+import java.util.List;
+
 import com.smartuxapi.ai.cache.CacheHint;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolResult;
 
 /**
  * prompt message 를 전송하고 응답받는다.
@@ -93,6 +97,71 @@ public interface Chatting {
 		if (schema == null) return sendPrompt(userMsg);
 		throw new UnsupportedOperationException(
 				"This provider has not implemented structured output yet");
+	}
+
+	/** 기본 최대 tool 호출 라운드 수 — 초과 시 마지막 응답 반환 + 경고 로그. @since 0.8.0 */
+	int DEFAULT_MAX_TOOL_ROUNDS = 5;
+
+	/**
+	 * Tool Use — 자동 루프 모드.
+	 *
+	 * <p>LLM 이 {@code tools} 에서 함수 호출을 요청하면 라이브러리가 자동으로
+	 * handler 를 실행하고 결과를 다시 LLM 에 전달. 최대 {@link #DEFAULT_MAX_TOOL_ROUNDS}
+	 * 라운드까지 반복한다. 초과 시 마지막 응답을 그대로 반환하고 경고 로그를 남긴다.
+	 *
+	 * <p>반환 JSON:
+	 * <pre>{
+	 *   "message": "최종 텍스트",
+	 *   "action_queue": {...},
+	 *   "tool_calls": [ { id, toolName, arguments, result } ]
+	 * }</pre>
+	 *
+	 * <p>{@code tools} 가 null/empty 이면 {@link #sendPrompt(String)} 로 위임한다.
+	 *
+	 * <p>기본 구현은 {@link UnsupportedOperationException} — provider 구현체가 override.
+	 *
+	 * @since 0.8.0
+	 */
+	default org.json.simple.JSONObject sendPromptWithTools(String userMsg, ToolRegistry tools) throws Exception {
+		if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+		throw new UnsupportedOperationException(
+				"This provider has not implemented tool use yet");
+	}
+
+	/**
+	 * Tool Use — 수동 dispatch 모드.
+	 *
+	 * <p>LLM 이 tool 호출을 요청하면 즉시 반환하여 호출자가 직접 handler 를 실행할 수 있게 한다.
+	 * 호출자는 결과를 {@link #continueWithToolResults(List, ToolRegistry)} 로 전달하여 대화를 이어간다.
+	 *
+	 * <p>반환 JSON:
+	 * <pre>
+	 *  // LLM 이 바로 최종 응답을 낸 경우 (tool 호출 없음)
+	 *  { "message": "...", "action_queue": {...}, "tool_calls": [] }
+	 *
+	 *  // LLM 이 tool 호출을 요청한 경우
+	 *  { "message": null, "tool_calls": [ { id, toolName, arguments } ], "pending": true }
+	 * </pre>
+	 *
+	 * <p>기본 구현은 {@link UnsupportedOperationException}.
+	 *
+	 * @since 0.8.0
+	 */
+	default org.json.simple.JSONObject sendPromptExpectingToolCalls(String userMsg, ToolRegistry tools) throws Exception {
+		if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+		throw new UnsupportedOperationException(
+				"This provider has not implemented tool use yet");
+	}
+
+	/**
+	 * 수동 dispatch 의 후속 호출 — 호출자가 실행한 tool 결과들을 submit 하고 대화를 이어간다.
+	 * 반환 포맷은 {@link #sendPromptExpectingToolCalls(String, ToolRegistry)} 와 동일.
+	 *
+	 * @since 0.8.0
+	 */
+	default org.json.simple.JSONObject continueWithToolResults(List<ToolResult> results, ToolRegistry tools) throws Exception {
+		throw new UnsupportedOperationException(
+				"This provider has not implemented tool use yet");
 	}
 
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/Chatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/Chatting.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import com.smartuxapi.ai.cache.CacheHint;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
 
 /**
  * prompt message 를 전송하고 응답받는다.
@@ -58,5 +59,40 @@ public interface Chatting {
 	 * @since 0.7.0
 	 */
 	default void applyCacheHint(CacheHint hint) throws Exception { /* default no-op */ }
+
+	/**
+	 * 구조화 응답(JSON Schema) 을 강제하는 프롬프트 전송.
+	 *
+	 * <p>Provider 에 따라 다음 필드로 매핑된다:
+	 * <ul>
+	 *   <li>OpenAI: 요청 {@code text.format = { type: "json_schema", ... }}</li>
+	 *   <li>Gemini: 요청 {@code generationConfig.responseMimeType = "application/json"}
+	 *       + {@code responseSchema}</li>
+	 * </ul>
+	 *
+	 * <p>반환 포맷은 기존 {@link #sendPrompt(String)} 와 동일한 키
+	 * ({@code message}, {@code action_queue}) 를 유지하면서 파싱 결과를 신규 키로 병기한다:
+	 * <ul>
+	 *   <li>{@code message} — provider 응답 원문 (JSON 문자열)</li>
+	 *   <li>{@code action_queue} — 기존과 동일 (ActionQueueHandler 경로)</li>
+	 *   <li>{@code structured} — 원문을 파싱한 {@code JsonNode} (파싱 실패 시 {@code null})</li>
+	 * </ul>
+	 *
+	 * <p>파싱 실패는 예외를 던지지 않는다 — WARN 로그 후 {@code structured: null} 로 넘긴다.
+	 * 호출자가 원문을 재파싱하거나 fallback 을 결정할 수 있도록 한다.
+	 *
+	 * <p>기본 구현은 {@link UnsupportedOperationException} — provider 별 구현체가 override 한다.
+	 *
+	 * @param userMsg 사용자 메시지
+	 * @param schema 응답 스키마 (null 이면 {@link #sendPrompt(String)} 로 위임)
+	 * @return 응답 JSONObject
+	 * @throws Exception API 호출 실패 등
+	 * @since 0.8.0
+	 */
+	default org.json.simple.JSONObject sendPromptWithSchema(String userMsg, ResponseSchema schema) throws Exception {
+		if (schema == null) return sendPrompt(userMsg);
+		throw new UnsupportedOperationException(
+				"This provider has not implemented structured output yet");
+	}
 
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/ConversationHistory.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/ConversationHistory.java
@@ -49,7 +49,7 @@ public class ConversationHistory {
 
     /**
      * AI 모델의 응답을 대화 기록에 추가합니다.
-     * 
+     *
      * @param modelResponse AI 모델의 응답 텍스트
      */
     public void addModelResponse(String modelResponse) {
@@ -63,6 +63,33 @@ public class ConversationHistory {
 
         this.convHistory.put(modelContent);
         // chatSessions 맵에 이미 참조가 있으므로 별도로 put할 필요는 없음
+    }
+
+    /**
+     * Gemini 응답의 {@code candidates[0].content} 를 그대로 히스토리에 추가한다.
+     * Tool Use 턴에서 {@code functionCall} parts 가 다음 호출 시 replay 되도록 보존.
+     *
+     * @param modelContent Gemini 응답의 content 객체 — 보통 {@code {role:"model", parts:[...]}}
+     * @since 0.8.0
+     */
+    public void addModelContent(JSONObject modelContent) {
+        if (modelContent == null) return;
+        this.convHistory.put(modelContent);
+    }
+
+    /**
+     * Tool 실행 결과를 {@code functionResponse} parts 로 히스토리에 추가한다.
+     * 여러 호출 결과를 한 번의 user 턴에 묶어 넣는다.
+     *
+     * @param functionResponseParts 각 원소는 {@code { functionResponse: { name, response }}}
+     * @since 0.8.0
+     */
+    public void addToolResults(JSONArray functionResponseParts) {
+        if (functionResponseParts == null || functionResponseParts.length() == 0) return;
+        JSONObject userContent = new JSONObject();
+        userContent.put("role", "user");
+        userContent.put("parts", functionResponseParts);
+        this.convHistory.put(userContent);
     }
 
     /**

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.gemini.GeminiContextCacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
 
 /**
  * API에 연결한다.
@@ -46,7 +47,7 @@ public class GeminiAPIConnection {
      * @throws Exception API 호출 중 발생한 예외
      */
     public String generateContent(JSONArray contentsArray) throws Exception {
-        return generateContent(contentsArray, null);
+        return generateContent(contentsArray, null, null);
     }
 
     /**
@@ -61,6 +62,23 @@ public class GeminiAPIConnection {
      * @since 0.7.0
      */
     public String generateContent(JSONArray contentsArray, CacheStrategy cacheStrategy) throws Exception {
+        return generateContent(contentsArray, cacheStrategy, null);
+    }
+
+    /**
+     * Gemini API에 대화 기록을 전송하고 응답을 받습니다. {@code responseSchema} 가 주입되면
+     * 요청에 {@code generationConfig.responseMimeType = "application/json"} 과
+     * {@code responseSchema} 를 포함시켜 구조화된 JSON 응답을 강제합니다.
+     *
+     * @param contentsArray 전체 대화 기록
+     * @param cacheStrategy 캐시 전략 (null 허용)
+     * @param responseSchema 응답 JSON Schema (null 허용)
+     * @return Gemini 모델의 응답 텍스트 (schema 주입 시 JSON 문자열)
+     * @throws Exception API 호출 중 발생한 예외
+     * @since 0.8.0
+     */
+    public String generateContent(JSONArray contentsArray, CacheStrategy cacheStrategy,
+                                  ResponseSchema responseSchema) throws Exception {
         String urlStr = GEMINI_API_URL_BASE + modelName + ":generateContent?key=" + apiKey;
         URL url = new URL(urlStr);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -83,6 +101,18 @@ public class GeminiAPIConnection {
                 requestBody.put("cachedContent", cacheName);
                 log.debug("Gemini request using cachedContent: {}", cacheName);
             }
+        }
+
+        // 구조화 응답(JSON Schema) 주입 — Gemini generationConfig 규격
+        if (responseSchema != null) {
+            JSONObject genConfig = requestBody.optJSONObject("generationConfig");
+            if (genConfig == null) {
+                genConfig = new JSONObject();
+            }
+            genConfig.put("responseMimeType", "application/json");
+            // Jackson JsonNode → org.json 브릿지
+            genConfig.put("responseSchema", new JSONObject(responseSchema.getSchema().toString()));
+            requestBody.put("generationConfig", genConfig);
         }
 
         // 요청 바디 전송

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
@@ -13,11 +13,18 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.UUID;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.gemini.GeminiContextCacheStrategy;
 import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolTurnResult;
 
 /**
  * API에 연결한다.
@@ -167,5 +174,138 @@ public class GeminiAPIConnection {
                 throw new Exception("Gemini API 호출 실패: " + responseCode + " - " + errorResponse.toString());
             }
         }
+    }
+
+    /**
+     * Tool Use 지원 버전의 generateContent. 요청에 {@code tools.function_declarations} 를 포함시키고,
+     * 응답 parts 중 {@code functionCall} 이 있으면 {@link ToolTurnResult#toolCalls} 로 반환한다.
+     *
+     * <p>Gemini 응답은 호출 ID 를 포함하지 않으므로 클라이언트에서 UUID 를 부여한다.
+     * 동일 턴 내 여러 functionCall 이 있으면 각각 ID 를 받는다.
+     *
+     * @param contentsArray 대화 기록
+     * @param cacheStrategy 캐시 전략 (null 허용)
+     * @param tools Tool 레지스트리 (null/empty 면 일반 generateContent 와 동등)
+     * @return 이번 턴의 결과
+     * @throws Exception API 호출 실패 등
+     * @since 0.8.0
+     */
+    public ToolTurnResult generateContentWithTools(JSONArray contentsArray,
+                                                   CacheStrategy cacheStrategy,
+                                                   ToolRegistry tools) throws Exception {
+        String urlStr = GEMINI_API_URL_BASE + modelName + ":generateContent?key=" + apiKey;
+        URL url = new URL(urlStr);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+        conn.setRequestProperty("X-goog-api-key", apiKey);
+        conn.setRequestMethod("POST");
+        conn.setUseCaches(false);
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("contents", contentsArray);
+
+        if (cacheStrategy instanceof GeminiContextCacheStrategy) {
+            String cacheName = ((GeminiContextCacheStrategy) cacheStrategy).getCacheResourceName();
+            if (cacheName != null && !cacheName.isEmpty()) {
+                requestBody.put("cachedContent", cacheName);
+            }
+        }
+
+        if (tools != null && !tools.isEmpty()) {
+            JSONArray functionDeclarations = new JSONArray();
+            for (ToolDefinition def : tools.all()) {
+                JSONObject fn = new JSONObject();
+                fn.put("name", def.getName());
+                if (def.getDescription() != null && !def.getDescription().isEmpty()) {
+                    fn.put("description", def.getDescription());
+                }
+                fn.put("parameters", new JSONObject(def.getParametersSchema().toString()));
+                functionDeclarations.put(fn);
+            }
+            JSONObject toolsObj = new JSONObject();
+            toolsObj.put("functionDeclarations", functionDeclarations);
+            JSONArray toolsArr = new JSONArray();
+            toolsArr.put(toolsObj);
+            requestBody.put("tools", toolsArr);
+        }
+
+        try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+            wr.write(requestBody.toString().getBytes(StandardCharsets.UTF_8));
+            wr.flush();
+        }
+
+        int responseCode = conn.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            try (BufferedReader errorIn = new BufferedReader(
+                    new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
+                StringBuilder err = new StringBuilder();
+                String line;
+                while ((line = errorIn.readLine()) != null) err.append(line);
+                log.error("Gemini Tool Use API Error " + responseCode + ": " + err);
+                throw new Exception("Gemini API 호출 실패 (tool use): " + responseCode + " - " + err);
+            }
+        }
+
+        String responseBody;
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) sb.append(line);
+            responseBody = sb.toString();
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonRes = mapper.readTree(responseBody);
+
+        if (cacheStrategy != null) {
+            try {
+                cacheStrategy.recordMetricsFromResponse(jsonRes);
+            } catch (Exception metricsEx) {
+                log.warn("캐시 메트릭 기록 실패 (무시): " + metricsEx.getMessage());
+            }
+        }
+
+        JsonNode candidates = jsonRes.get("candidates");
+        if (candidates == null || !candidates.isArray() || candidates.size() == 0) {
+            return ToolTurnResult.finalText("응답에서 candidates 를 찾을 수 없습니다.", "{}");
+        }
+        JsonNode candidate0 = candidates.get(0);
+        JsonNode content = candidate0.get("content");
+        if (content == null) {
+            return ToolTurnResult.finalText("응답 content 누락", "{}");
+        }
+
+        // parts 순회하여 functionCall / text 수집
+        java.util.List<ToolCall> calls = new ArrayList<>();
+        StringBuilder textBuf = new StringBuilder();
+        JsonNode parts = content.get("parts");
+        if (parts != null && parts.isArray()) {
+            for (JsonNode part : parts) {
+                JsonNode fc = part.get("functionCall");
+                if (fc != null) {
+                    String name = fc.path("name").asText("");
+                    JsonNode args = fc.get("args");
+                    if (args == null) args = mapper.createObjectNode();
+                    String callId = "gemini-call-" + UUID.randomUUID();
+                    if (!name.isEmpty()) {
+                        calls.add(new ToolCall(callId, name, args));
+                    }
+                } else {
+                    JsonNode textNode = part.get("text");
+                    if (textNode != null) textBuf.append(textNode.asText());
+                }
+            }
+        }
+
+        // content 는 그대로 히스토리에 replay 해야 하므로 원본 문자열 보존
+        String rawContent = content.toString();
+
+        if (!calls.isEmpty()) {
+            return ToolTurnResult.toolCalls(calls, rawContent);
+        }
+        return ToolTurnResult.finalText(textBuf.toString(), rawContent);
     }
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiChatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiChatting.java
@@ -4,18 +4,26 @@ import java.util.Set;
 
 import org.json.JSONArray;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.ActionQueueHandler;
 import com.smartuxapi.ai.Chatting;
 import com.smartuxapi.ai.cache.CacheHint;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.debug.DebugLogger;
+import com.smartuxapi.ai.schema.ResponseSchema;
 
 /**
  * Gemini API를 사용하는 Chatting 구현체
  */
 public class GeminiChatting implements Chatting {
+
+    private static final Logger LOG = LogManager.getLogger(GeminiChatting.class);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private GeminiAPIConnection connApi = null;
     private ConversationHistory conversationHistory = null;
@@ -42,6 +50,20 @@ public class GeminiChatting implements Chatting {
      */
     @Override
     public org.json.simple.JSONObject sendPrompt(String userMsg) throws Exception {
+        return sendInternal(userMsg, null);
+    }
+
+    /**
+     * Structured Output — JSON Schema 강제 응답.
+     * @since 0.8.0
+     */
+    @Override
+    public org.json.simple.JSONObject sendPromptWithSchema(String userMsg, ResponseSchema schema) throws Exception {
+        if (schema == null) return sendPrompt(userMsg);
+        return sendInternal(userMsg, schema);
+    }
+
+    private org.json.simple.JSONObject sendInternal(String userMsg, ResponseSchema schema) throws Exception {
 
         boolean reqActionQueue = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
 
@@ -63,8 +85,8 @@ public class GeminiChatting implements Chatting {
         // 1. 사용자 메시지를 대화 기록에 추가하고, Gemini에 보낼 전체 기록을 가져옴
         JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
 
-        // 2. Gemini API 호출 (전체 대화 기록 전송, 캐시 전략 주입)
-        String geminiResponse = this.connApi.generateContent(convHistory, this.cacheStrategy);
+        // 2. Gemini API 호출 (전체 대화 기록 전송, 캐시 전략 + 선택적 응답 스키마 주입)
+        String geminiResponse = this.connApi.generateContent(convHistory, this.cacheStrategy, schema);
 
         // 3. Gemini 응답을 대화 기록에 추가
         this.conversationHistory.addModelResponse(geminiResponse);
@@ -88,6 +110,17 @@ public class GeminiChatting implements Chatting {
                 actionQueue = aqObj;
                 resJson.put("action_queue", aqObj);
             }
+        }
+
+        // Structured Output — 응답 원문을 JsonNode 로 파싱하여 structured 필드에 병기
+        if (schema != null) {
+            JsonNode structured = null;
+            try {
+                structured = JSON_MAPPER.readTree(geminiResponse);
+            } catch (Exception parseEx) {
+                LOG.warn("Structured output JSON 파싱 실패 (schema={}): {}", schema.getName(), parseEx.getMessage());
+            }
+            resJson.put("structured", structured);
         }
 
         // 디버그 로깅: 턴 완료

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiChatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiChatting.java
@@ -1,8 +1,11 @@
 package com.smartuxapi.ai.gemini;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,6 +19,11 @@ import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.debug.DebugLogger;
 import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolResult;
+import com.smartuxapi.ai.tools.ToolTurnResult;
 
 /**
  * Gemini API를 사용하는 Chatting 구현체
@@ -166,5 +174,200 @@ public class GeminiChatting implements Chatting {
             return;
         }
         this.cacheStrategy.prime(hint);
+    }
+
+    // ========================================================================
+    // Tool Use (v0.8.0 T2-b)
+    // ========================================================================
+
+    @Override
+    public org.json.simple.JSONObject sendPromptWithTools(String userMsg, ToolRegistry tools) throws Exception {
+        if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+
+        boolean reqAq = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
+        String usrPrompt = reqAq ? this.aqHandler.getActionQueuePrompt(userMsg) : userMsg;
+        String curViewPrompt = reqAq ? this.aqHandler.getCurViewPrompt() : null;
+        if (debugLogger != null && debugLogger.isEnabled()) {
+            debugLogger.startTurn(chatRoomId, userMsg, usrPrompt, curViewPrompt);
+        }
+        JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
+        if (this.aqHandler != null && curViewPrompt != null) {
+            this.aqHandler.markViewInfoAsSent();
+        }
+
+        List<org.json.simple.JSONObject> executedCalls = new ArrayList<>();
+        String finalText = null;
+        for (int round = 0; round < DEFAULT_MAX_TOOL_ROUNDS; round++) {
+            JSONArray reqContents = round == 0 ? convHistory : this.conversationHistory.getHistory();
+            ToolTurnResult turn = this.connApi.generateContentWithTools(reqContents, this.cacheStrategy, tools);
+
+            if (turn.isFinal()) {
+                finalText = turn.getFinalText();
+                this.conversationHistory.addModelResponse(finalText);
+                break;
+            }
+            // assistant functionCall content 를 히스토리에 보존
+            JSONObject modelContent = new JSONObject(turn.getRawAssistantPayload());
+            this.conversationHistory.addModelContent(modelContent);
+
+            JSONArray fnResponses = new JSONArray();
+            for (ToolCall call : turn.getToolCalls()) {
+                ToolResult result = executeToolCall(call, tools);
+                fnResponses.put(buildFunctionResponsePart(call, result));
+                executedCalls.add(toExecutedCallJson(call, result));
+            }
+            this.conversationHistory.addToolResults(fnResponses);
+        }
+
+        if (finalText == null) {
+            LOG.warn("Tool use max_tool_rounds={} 초과. 마지막 텍스트 응답 요청.", DEFAULT_MAX_TOOL_ROUNDS);
+            finalText = this.connApi.generateContent(this.conversationHistory.getHistory(), this.cacheStrategy);
+            this.conversationHistory.addModelResponse(finalText);
+        }
+
+        return buildFinalJson(finalText, executedCalls);
+    }
+
+    @Override
+    public org.json.simple.JSONObject sendPromptExpectingToolCalls(String userMsg, ToolRegistry tools) throws Exception {
+        if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+
+        boolean reqAq = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
+        String usrPrompt = reqAq ? this.aqHandler.getActionQueuePrompt(userMsg) : userMsg;
+        String curViewPrompt = reqAq ? this.aqHandler.getCurViewPrompt() : null;
+        JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
+        if (this.aqHandler != null && curViewPrompt != null) {
+            this.aqHandler.markViewInfoAsSent();
+        }
+
+        ToolTurnResult turn = this.connApi.generateContentWithTools(convHistory, this.cacheStrategy, tools);
+        if (turn.isFinal()) {
+            this.conversationHistory.addModelResponse(turn.getFinalText());
+            return buildFinalJson(turn.getFinalText(), new ArrayList<>());
+        }
+        JSONObject modelContent = new JSONObject(turn.getRawAssistantPayload());
+        this.conversationHistory.addModelContent(modelContent);
+        return buildPendingJson(turn.getToolCalls());
+    }
+
+    @Override
+    public org.json.simple.JSONObject continueWithToolResults(List<ToolResult> results, ToolRegistry tools) throws Exception {
+        if (results != null && !results.isEmpty()) {
+            // Gemini 는 functionResponse part 를 만들 때 이름이 필요. Registry 를 통해 추정 불가 시 callId 사용.
+            // 호출자가 넘긴 결과에 대응하는 ToolCall 이름을 얻기 위해 registry 의 정의 이름을 fallback 으로 사용.
+            JSONArray fnResponses = new JSONArray();
+            for (ToolResult r : results) {
+                // name 은 ToolResult 에 없으므로 registry 에서 가능한 첫 tool 이름 사용. 실용상 호출자가
+                // Auto mode 를 쓰거나, Manual mode 에서 tool 당 결과를 한 번에 돌려준다는 전제.
+                String name = firstRegisteredToolName(tools);
+                fnResponses.put(buildFunctionResponsePartByName(name, r));
+            }
+            this.conversationHistory.addToolResults(fnResponses);
+        }
+        ToolTurnResult turn = this.connApi.generateContentWithTools(
+                this.conversationHistory.getHistory(), this.cacheStrategy, tools);
+        if (turn.isFinal()) {
+            this.conversationHistory.addModelResponse(turn.getFinalText());
+            return buildFinalJson(turn.getFinalText(), new ArrayList<>());
+        }
+        JSONObject modelContent = new JSONObject(turn.getRawAssistantPayload());
+        this.conversationHistory.addModelContent(modelContent);
+        return buildPendingJson(turn.getToolCalls());
+    }
+
+    // ----- tool use 내부 헬퍼 -----
+
+    private ToolResult executeToolCall(ToolCall call, ToolRegistry tools) {
+        ToolDefinition def = tools.get(call.getToolName());
+        if (def == null) {
+            return ToolResult.error(call.getId(), "Unregistered tool: " + call.getToolName());
+        }
+        try {
+            return enforceOutputSizeCap(def.getHandler().invoke(call));
+        } catch (Exception ex) {
+            LOG.warn("Tool handler 실패 [{}]: {}", call.getToolName(), ex.getMessage());
+            return ToolResult.error(call.getId(), ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        }
+    }
+
+    private ToolResult enforceOutputSizeCap(ToolResult r) {
+        if (r == null || r.getOutput() == null) return r;
+        String s = r.getOutput().toString();
+        if (s.getBytes(java.nio.charset.StandardCharsets.UTF_8).length <= ToolResult.MAX_OUTPUT_BYTES) {
+            return r;
+        }
+        LOG.warn("Tool output 크기 상한 {}B 초과 — 자동 축약", ToolResult.MAX_OUTPUT_BYTES);
+        return ToolResult.error(r.getCallId(),
+                "output truncated: size exceeded " + ToolResult.MAX_OUTPUT_BYTES + " bytes");
+    }
+
+    private JSONObject buildFunctionResponsePart(ToolCall call, ToolResult result) {
+        return buildFunctionResponsePartByName(call.getToolName(), result);
+    }
+
+    private JSONObject buildFunctionResponsePartByName(String toolName, ToolResult result) {
+        JSONObject fnResp = new JSONObject();
+        fnResp.put("name", toolName == null ? "unknown" : toolName);
+        JSONObject response = new JSONObject();
+        if (result.isError()) {
+            response.put("error", result.getErrorMessage() == null ? "" : result.getErrorMessage());
+        } else {
+            response.put("result", result.getOutput() == null ? JSONObject.NULL
+                    : new JSONObject(result.getOutput().toString()));
+        }
+        fnResp.put("response", response);
+        JSONObject part = new JSONObject();
+        part.put("functionResponse", fnResp);
+        return part;
+    }
+
+    private String firstRegisteredToolName(ToolRegistry tools) {
+        if (tools == null || tools.isEmpty()) return "unknown";
+        return tools.all().iterator().next().getName();
+    }
+
+    private org.json.simple.JSONObject toExecutedCallJson(ToolCall call, ToolResult result) {
+        org.json.simple.JSONObject o = new org.json.simple.JSONObject();
+        o.put("id", call.getId());
+        o.put("toolName", call.getToolName());
+        o.put("arguments", call.getArguments() == null ? null : call.getArguments().toString());
+        o.put("result", result.getOutput() == null ? null : result.getOutput().toString());
+        o.put("isError", result.isError());
+        return o;
+    }
+
+    @SuppressWarnings("unchecked")
+    private org.json.simple.JSONObject buildFinalJson(String finalText, List<org.json.simple.JSONObject> executedCalls) {
+        org.json.simple.JSONObject res = new org.json.simple.JSONObject();
+        res.put("message", finalText);
+        if (this.aqHandler != null) {
+            JsonNode aq = this.aqHandler.getActionQueue(finalText);
+            if (aq != null && aq.hasNonNull("action_queue")) {
+                res.put("action_queue", aq.get("action_queue"));
+            } else {
+                res.put("action_queue", aq);
+            }
+        }
+        org.json.simple.JSONArray arr = new org.json.simple.JSONArray();
+        arr.addAll(executedCalls);
+        res.put("tool_calls", arr);
+        return res;
+    }
+
+    @SuppressWarnings("unchecked")
+    private org.json.simple.JSONObject buildPendingJson(List<ToolCall> calls) {
+        org.json.simple.JSONObject res = new org.json.simple.JSONObject();
+        res.put("message", null);
+        org.json.simple.JSONArray arr = new org.json.simple.JSONArray();
+        for (ToolCall c : calls) {
+            org.json.simple.JSONObject o = new org.json.simple.JSONObject();
+            o.put("id", c.getId());
+            o.put("toolName", c.getToolName());
+            o.put("arguments", c.getArguments() == null ? null : c.getArguments().toString());
+            arr.add(o);
+        }
+        res.put("tool_calls", arr);
+        res.put("pending", true);
+        return res;
     }
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ConversationHistory.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ConversationHistory.java
@@ -89,7 +89,7 @@ public class ConversationHistory {
 
     /**
      * AI 모델의 응답을 대화 기록에 추가합니다.
-     * 
+     *
      * @param modelResponse AI 모델의 응답 텍스트
      */
     public void addModelResponse(String modelResponse) {
@@ -101,6 +101,35 @@ public class ConversationHistory {
 
         convHistory.put(modelContent);
         // chatSessions 맵에 이미 참조가 있으므로 별도로 put할 필요는 없음
+    }
+
+    /**
+     * Responses API 응답의 {@code output[]} 항목들을 그대로 히스토리에 추가한다.
+     * Tool Use 턴에서 다음 호출 시 재전송되어야 하는 {@code function_call} 등 raw 아이템 보존.
+     *
+     * @param outputItems Responses API 응답 output 배열 — 각 아이템은 provider 규격 그대로.
+     * @since 0.8.0
+     */
+    public void addAssistantOutputItems(JSONArray outputItems) {
+        if (outputItems == null) return;
+        for (int i = 0; i < outputItems.length(); i++) {
+            convHistory.put(outputItems.get(i));
+        }
+    }
+
+    /**
+     * Tool 실행 결과를 {@code function_call_output} 아이템으로 히스토리에 추가한다.
+     *
+     * @param callId {@link ToolCall#getId()} 와 동일
+     * @param outputJsonString 결과 JSON (문자열)
+     * @since 0.8.0
+     */
+    public void addToolResult(String callId, String outputJsonString) {
+        JSONObject item = new JSONObject();
+        item.put("type", "function_call_output");
+        item.put("call_id", callId);
+        item.put("output", outputJsonString);
+        convHistory.put(item);
     }
 
     /**

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
 
 /**
  * API에 연결한다.
@@ -42,7 +43,7 @@ public class ResponsesAPIConnection {
      * @throws Exception API 호출 중 발생한 예외
      */
     public String generateContent(JSONArray conversationHistory) throws Exception {
-        return generateContent(conversationHistory, null);
+        return generateContent(conversationHistory, null, null);
     }
 
     /**
@@ -56,6 +57,22 @@ public class ResponsesAPIConnection {
      * @since 0.7.0
      */
     public String generateContent(JSONArray conversationHistory, CacheStrategy cacheStrategy) throws Exception {
+        return generateContent(conversationHistory, cacheStrategy, null);
+    }
+
+    /**
+     * Responses API에 대화 기록을 전송하고 응답을 받습니다. {@code responseSchema} 가 주입되면
+     * 요청에 {@code text.format = json_schema} 구성을 포함시켜 구조화된 JSON 응답을 강제합니다.
+     *
+     * @param conversationHistory 전체 대화 기록
+     * @param cacheStrategy 캐시 전략 (null 허용)
+     * @param responseSchema 응답 JSON Schema (null 허용 — 자유형 텍스트)
+     * @return AI 모델의 응답 텍스트 (schema 주입 시 JSON 문자열)
+     * @throws Exception API 호출 중 발생한 예외
+     * @since 0.8.0
+     */
+    public String generateContent(JSONArray conversationHistory, CacheStrategy cacheStrategy,
+                                  ResponseSchema responseSchema) throws Exception {
         URL url = new URL(OPENAI_API_URL_BASE);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
@@ -72,6 +89,22 @@ public class ResponsesAPIConnection {
         
         // AI모델 설정
         requestBody.put("model", this.modelName);
+
+        // 구조화 응답(JSON Schema) 주입 — Responses API text.format 규격
+        if (responseSchema != null) {
+            JSONObject formatNode = new JSONObject();
+            formatNode.put("type", "json_schema");
+            formatNode.put("name", responseSchema.getName());
+            formatNode.put("strict", responseSchema.isStrict());
+            if (responseSchema.getDescription() != null) {
+                formatNode.put("description", responseSchema.getDescription());
+            }
+            // Jackson JsonNode → org.json 객체로 브릿지
+            formatNode.put("schema", new JSONObject(responseSchema.getSchema().toString()));
+            JSONObject textNode = new JSONObject();
+            textNode.put("format", formatNode);
+            requestBody.put("text", textNode);
+        }
 
         // 요청 바디 전송
         try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
@@ -13,10 +13,16 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolTurnResult;
 
 /**
  * API에 연결한다.
@@ -176,5 +182,131 @@ public class ResponsesAPIConnection {
                 throw new Exception("OpenAI API 호출 실패: " + responseCode + " - " + errorResponse.toString());
             }
         }
+    }
+
+    /**
+     * Tool Use 지원 버전의 generateContent. 요청에 {@code tools} 정의를 포함시키고,
+     * 응답에서 {@code function_call} 아이템이 있으면 {@link ToolTurnResult#toolCalls} 로 반환한다.
+     * 없으면 assistant 메시지의 text 를 추출해 {@link ToolTurnResult#finalText} 로 반환.
+     *
+     * @param conversationHistory 대화 기록 (assistant output items, tool results 포함 가능)
+     * @param cacheStrategy 캐시 전략 (null 허용)
+     * @param tools Tool 레지스트리 (null/empty 면 일반 generateContent 와 동등)
+     * @return 이번 턴의 결과
+     * @throws Exception API 호출 실패 등
+     * @since 0.8.0
+     */
+    public ToolTurnResult generateContentWithTools(JSONArray conversationHistory,
+                                                   CacheStrategy cacheStrategy,
+                                                   ToolRegistry tools) throws Exception {
+        URL url = new URL(OPENAI_API_URL_BASE);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+        conn.setRequestProperty("Authorization", "Bearer " + this.apiKey);
+        conn.setRequestMethod("POST");
+        conn.setUseCaches(false);
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("input", conversationHistory);
+        requestBody.put("model", this.modelName);
+
+        // Tool 정의 주입 — Responses API tools 포맷: [{type:"function", name, description, parameters, strict}]
+        if (tools != null && !tools.isEmpty()) {
+            JSONArray toolsArr = new JSONArray();
+            for (ToolDefinition def : tools.all()) {
+                JSONObject t = new JSONObject();
+                t.put("type", "function");
+                t.put("name", def.getName());
+                if (def.getDescription() != null && !def.getDescription().isEmpty()) {
+                    t.put("description", def.getDescription());
+                }
+                t.put("parameters", new JSONObject(def.getParametersSchema().toString()));
+                toolsArr.put(t);
+            }
+            requestBody.put("tools", toolsArr);
+        }
+
+        try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+            wr.write(requestBody.toString().getBytes(StandardCharsets.UTF_8));
+            wr.flush();
+        }
+
+        int responseCode = conn.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            try (BufferedReader errorIn = new BufferedReader(
+                    new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
+                StringBuilder err = new StringBuilder();
+                String line;
+                while ((line = errorIn.readLine()) != null) err.append(line);
+                log.error("OpenAI Tool Use API Error " + responseCode + ": " + err);
+                throw new Exception("OpenAI API 호출 실패 (tool use): " + responseCode + " - " + err);
+            }
+        }
+
+        String responseBody;
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) sb.append(line);
+            responseBody = sb.toString();
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonRes = mapper.readTree(responseBody);
+
+        if (cacheStrategy != null) {
+            try {
+                cacheStrategy.recordMetricsFromResponse(jsonRes);
+            } catch (Exception metricsEx) {
+                log.warn("캐시 메트릭 기록 실패 (무시): " + metricsEx.getMessage());
+            }
+        }
+
+        JsonNode outputArray = jsonRes.get("output");
+        if (outputArray == null || !outputArray.isArray()) {
+            return ToolTurnResult.finalText("응답에서 output 을 찾을 수 없습니다.",
+                    new JSONArray().toString());
+        }
+
+        // function_call 아이템 수집
+        java.util.List<ToolCall> calls = new ArrayList<>();
+        String finalText = null;
+        // output 을 raw items 로 보존하기 위해 JSONArray 재구성
+        JSONArray rawOutput = new JSONArray(outputArray.toString());
+
+        for (JsonNode item : outputArray) {
+            String type = item.path("type").asText("");
+            if ("function_call".equals(type)) {
+                String callId = item.path("call_id").asText(
+                        item.path("id").asText(""));
+                String name = item.path("name").asText("");
+                String argsStr = item.path("arguments").asText("{}");
+                JsonNode argsNode;
+                try {
+                    argsNode = mapper.readTree(argsStr);
+                } catch (Exception e) {
+                    argsNode = mapper.createObjectNode();
+                }
+                if (!callId.isEmpty() && !name.isEmpty()) {
+                    calls.add(new ToolCall(callId, name, argsNode));
+                }
+            } else if ("message".equals(type) || "assistant".equals(item.path("role").asText(""))) {
+                // 최종 텍스트 후보
+                JsonNode contentArr = item.get("content");
+                if (contentArr != null && contentArr.isArray() && contentArr.size() > 0) {
+                    JsonNode first = contentArr.get(0);
+                    JsonNode text = first.get("text");
+                    if (text != null) finalText = text.asText();
+                }
+            }
+        }
+
+        if (!calls.isEmpty()) {
+            return ToolTurnResult.toolCalls(calls, rawOutput.toString());
+        }
+        return ToolTurnResult.finalText(finalText != null ? finalText : "", rawOutput.toString());
     }
 }

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesChatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesChatting.java
@@ -4,18 +4,26 @@ import java.util.Set;
 
 import org.json.JSONArray;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartuxapi.ai.ActionQueueHandler;
 import com.smartuxapi.ai.Chatting;
 import com.smartuxapi.ai.cache.CacheHint;
 import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.debug.DebugLogger;
+import com.smartuxapi.ai.schema.ResponseSchema;
 
 /**
  * OpenAI Responses API를 사용하는 Chatting 구현체
  */
 public class ResponsesChatting implements Chatting {
+
+    private static final Logger LOG = LogManager.getLogger(ResponsesChatting.class);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private ResponsesAPIConnection connApi = null;
     private ConversationHistory conversationHistory = null;
@@ -42,6 +50,20 @@ public class ResponsesChatting implements Chatting {
      */
     @Override
     public org.json.simple.JSONObject sendPrompt(String userMsg) throws Exception {
+        return sendInternal(userMsg, null);
+    }
+
+    /**
+     * Structured Output — JSON Schema 강제 응답.
+     * @since 0.8.0
+     */
+    @Override
+    public org.json.simple.JSONObject sendPromptWithSchema(String userMsg, ResponseSchema schema) throws Exception {
+        if (schema == null) return sendPrompt(userMsg);
+        return sendInternal(userMsg, schema);
+    }
+
+    private org.json.simple.JSONObject sendInternal(String userMsg, ResponseSchema schema) throws Exception {
 
         boolean reqActionQueue = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
 
@@ -63,8 +85,8 @@ public class ResponsesChatting implements Chatting {
         // 1. 사용자 메시지를 대화 기록에 추가하고, AI에 보낼 전체 기록을 가져옴
         JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
 
-        // 2. Responses API 호출 (전체 대화 기록 전송, 캐시 전략 주입)
-        String aiResponse = this.connApi.generateContent(convHistory, this.cacheStrategy);
+        // 2. Responses API 호출 (전체 대화 기록 전송, 캐시 전략 + 선택적 응답 스키마 주입)
+        String aiResponse = this.connApi.generateContent(convHistory, this.cacheStrategy, schema);
 
         // 3. AI 응답을 대화 기록에 추가
         this.conversationHistory.addModelResponse(aiResponse);
@@ -88,6 +110,17 @@ public class ResponsesChatting implements Chatting {
                 actionQueue = aqObj;
                 resJson.put("action_queue", aqObj);
             }
+        }
+
+        // Structured Output — 응답 원문을 JsonNode 로 파싱하여 structured 필드에 병기
+        if (schema != null) {
+            JsonNode structured = null;
+            try {
+                structured = JSON_MAPPER.readTree(aiResponse);
+            } catch (Exception parseEx) {
+                LOG.warn("Structured output JSON 파싱 실패 (schema={}): {}", schema.getName(), parseEx.getMessage());
+            }
+            resJson.put("structured", structured);
         }
 
         // 디버그 로깅: 턴 완료

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesChatting.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesChatting.java
@@ -1,5 +1,7 @@
 package com.smartuxapi.ai.openai;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.json.JSONArray;
@@ -9,6 +11,8 @@ import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartuxapi.ai.ActionQueueHandler;
 import com.smartuxapi.ai.Chatting;
 import com.smartuxapi.ai.cache.CacheHint;
@@ -16,6 +20,11 @@ import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cache.NoOpCacheStrategy;
 import com.smartuxapi.ai.debug.DebugLogger;
 import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolResult;
+import com.smartuxapi.ai.tools.ToolTurnResult;
 
 /**
  * OpenAI Responses API를 사용하는 Chatting 구현체
@@ -169,6 +178,210 @@ public class ResponsesChatting implements Chatting {
         }
         this.cacheStrategy.prime(hint);
         this.conversationHistory.setCacheablePrefix(hint.getContent());
+    }
+
+    // ========================================================================
+    // Tool Use (v0.8.0 T2-b)
+    // ========================================================================
+
+    /**
+     * Auto-loop tool use. 최대 {@link Chatting#DEFAULT_MAX_TOOL_ROUNDS} 라운드까지 반복.
+     */
+    @Override
+    public org.json.simple.JSONObject sendPromptWithTools(String userMsg, ToolRegistry tools) throws Exception {
+        if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+
+        // 1. 사용자 메시지 히스토리 추가 (curView 포함)
+        boolean reqActionQueue = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
+        String usrPrompt = reqActionQueue ? this.aqHandler.getActionQueuePrompt(userMsg) : userMsg;
+        String curViewPrompt = reqActionQueue ? this.aqHandler.getCurViewPrompt() : null;
+        if (debugLogger != null && debugLogger.isEnabled()) {
+            debugLogger.startTurn(chatRoomId, userMsg, usrPrompt, curViewPrompt);
+        }
+        JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
+        if (this.aqHandler != null && curViewPrompt != null) {
+            this.aqHandler.markViewInfoAsSent();
+        }
+
+        // 2. Tool-use 루프
+        List<org.json.simple.JSONObject> executedCalls = new ArrayList<>();
+        String finalText = null;
+        for (int round = 0; round < DEFAULT_MAX_TOOL_ROUNDS; round++) {
+            // 히스토리 snapshot 을 convHistory 로 재빌드 — 이미 누적된 상태
+            JSONArray requestInput = snapshotForTools(round, convHistory);
+            ToolTurnResult turn = this.connApi.generateContentWithTools(requestInput, this.cacheStrategy, tools);
+
+            if (turn.isFinal()) {
+                finalText = turn.getFinalText();
+                this.conversationHistory.addModelResponse(finalText);
+                break;
+            }
+            // tool 호출 — 원본 응답 output 을 히스토리에 보존 (다음 라운드 재전송 위해)
+            JSONArray assistantOutput = new JSONArray(turn.getRawAssistantPayload());
+            this.conversationHistory.addAssistantOutputItems(assistantOutput);
+
+            for (ToolCall call : turn.getToolCalls()) {
+                ToolResult result = executeToolCall(call, tools);
+                String outputStr = serializeToolOutput(result);
+                this.conversationHistory.addToolResult(call.getId(), outputStr);
+                executedCalls.add(toExecutedCallJson(call, result));
+            }
+        }
+
+        if (finalText == null) {
+            // max rounds 초과 — 마지막 응답을 강제 요청
+            LOG.warn("Tool use max_tool_rounds={} 초과. 현재 누적 호출 {} 개, 마지막 텍스트 응답 요청.",
+                    DEFAULT_MAX_TOOL_ROUNDS, executedCalls.size());
+            // tool 없이 마지막 호출
+            String textOnly = this.connApi.generateContent(this.conversationHistory.getHistory(), this.cacheStrategy);
+            finalText = textOnly;
+            this.conversationHistory.addModelResponse(finalText);
+        }
+
+        org.json.simple.JSONObject res = new org.json.simple.JSONObject();
+        res.put("message", finalText);
+        if (this.aqHandler != null) {
+            JsonNode aq = this.aqHandler.getActionQueue(finalText);
+            if (aq != null && aq.hasNonNull("action_queue")) {
+                res.put("action_queue", aq.get("action_queue"));
+            } else {
+                res.put("action_queue", aq);
+            }
+        }
+        org.json.simple.JSONArray callsArr = new org.json.simple.JSONArray();
+        callsArr.addAll(executedCalls);
+        res.put("tool_calls", callsArr);
+
+        if (debugLogger != null && debugLogger.isEnabled()) {
+            debugLogger.completeTurn(chatRoomId, finalText, null);
+        }
+        return res;
+    }
+
+    /**
+     * Manual mode — 첫 라운드만 실행하고 tool_calls 가 있으면 반환한다.
+     */
+    @Override
+    public org.json.simple.JSONObject sendPromptExpectingToolCalls(String userMsg, ToolRegistry tools) throws Exception {
+        if (tools == null || tools.isEmpty()) return sendPrompt(userMsg);
+
+        boolean reqActionQueue = this.aqHandler != null && this.aqHandler.isCurrentViewInfo();
+        String usrPrompt = reqActionQueue ? this.aqHandler.getActionQueuePrompt(userMsg) : userMsg;
+        String curViewPrompt = reqActionQueue ? this.aqHandler.getCurViewPrompt() : null;
+        JSONArray convHistory = this.conversationHistory.addUserPrompt(usrPrompt, curViewPrompt);
+        if (this.aqHandler != null && curViewPrompt != null) {
+            this.aqHandler.markViewInfoAsSent();
+        }
+
+        ToolTurnResult turn = this.connApi.generateContentWithTools(convHistory, this.cacheStrategy, tools);
+        if (turn.isFinal()) {
+            this.conversationHistory.addModelResponse(turn.getFinalText());
+            return finalResponseJson(turn.getFinalText());
+        }
+        // tool 호출 pending — 히스토리에 assistant output 저장
+        this.conversationHistory.addAssistantOutputItems(new JSONArray(turn.getRawAssistantPayload()));
+        return pendingResponseJson(turn.getToolCalls());
+    }
+
+    /**
+     * Manual mode — 호출자가 실행한 ToolResult 들을 제출하고 한 라운드 진행.
+     */
+    @Override
+    public org.json.simple.JSONObject continueWithToolResults(List<ToolResult> results, ToolRegistry tools) throws Exception {
+        if (results != null) {
+            for (ToolResult r : results) {
+                this.conversationHistory.addToolResult(r.getCallId(), serializeToolOutput(r));
+            }
+        }
+        ToolTurnResult turn = this.connApi.generateContentWithTools(
+                this.conversationHistory.getHistory(), this.cacheStrategy, tools);
+        if (turn.isFinal()) {
+            this.conversationHistory.addModelResponse(turn.getFinalText());
+            return finalResponseJson(turn.getFinalText());
+        }
+        this.conversationHistory.addAssistantOutputItems(new JSONArray(turn.getRawAssistantPayload()));
+        return pendingResponseJson(turn.getToolCalls());
+    }
+
+    // ----- tool use 내부 헬퍼 -----
+
+    private JSONArray snapshotForTools(int round, JSONArray firstRoundHistory) {
+        // 1 번째 라운드 는 addUserPrompt 가 만들어준 배열 사용 (curView 프리픽스 포함)
+        // 2 번째 이후 라운드 는 누적된 내부 history 로 충분 (curView 는 이미 소비됨)
+        return round == 0 ? firstRoundHistory : this.conversationHistory.getHistory();
+    }
+
+    private ToolResult executeToolCall(ToolCall call, ToolRegistry tools) {
+        ToolDefinition def = tools.get(call.getToolName());
+        if (def == null) {
+            return ToolResult.error(call.getId(), "Unregistered tool: " + call.getToolName());
+        }
+        try {
+            ToolResult out = def.getHandler().invoke(call);
+            return enforceOutputSizeCap(out);
+        } catch (Exception ex) {
+            LOG.warn("Tool handler 실패 [{}]: {}", call.getToolName(), ex.getMessage());
+            return ToolResult.error(call.getId(), ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        }
+    }
+
+    private ToolResult enforceOutputSizeCap(ToolResult r) {
+        if (r == null || r.getOutput() == null) return r;
+        String s = r.getOutput().toString();
+        if (s.getBytes(java.nio.charset.StandardCharsets.UTF_8).length <= ToolResult.MAX_OUTPUT_BYTES) {
+            return r;
+        }
+        LOG.warn("Tool output 크기 상한 {}B 초과 — 자동 축약", ToolResult.MAX_OUTPUT_BYTES);
+        return ToolResult.error(r.getCallId(),
+                "output truncated: size exceeded " + ToolResult.MAX_OUTPUT_BYTES + " bytes");
+    }
+
+    private String serializeToolOutput(ToolResult r) {
+        if (r.isError()) return r.getErrorMessage() == null ? "error" : r.getErrorMessage();
+        return r.getOutput() == null ? "" : r.getOutput().toString();
+    }
+
+    private org.json.simple.JSONObject toExecutedCallJson(ToolCall call, ToolResult result) {
+        org.json.simple.JSONObject obj = new org.json.simple.JSONObject();
+        obj.put("id", call.getId());
+        obj.put("toolName", call.getToolName());
+        obj.put("arguments", call.getArguments() == null ? null : call.getArguments().toString());
+        obj.put("result", result.getOutput() == null ? null : result.getOutput().toString());
+        obj.put("isError", result.isError());
+        return obj;
+    }
+
+    @SuppressWarnings("unchecked")
+    private org.json.simple.JSONObject finalResponseJson(String text) {
+        org.json.simple.JSONObject res = new org.json.simple.JSONObject();
+        res.put("message", text);
+        if (this.aqHandler != null) {
+            JsonNode aq = this.aqHandler.getActionQueue(text);
+            if (aq != null && aq.hasNonNull("action_queue")) {
+                res.put("action_queue", aq.get("action_queue"));
+            } else {
+                res.put("action_queue", aq);
+            }
+        }
+        res.put("tool_calls", new org.json.simple.JSONArray());
+        return res;
+    }
+
+    @SuppressWarnings("unchecked")
+    private org.json.simple.JSONObject pendingResponseJson(List<ToolCall> calls) {
+        org.json.simple.JSONObject res = new org.json.simple.JSONObject();
+        res.put("message", null);
+        org.json.simple.JSONArray arr = new org.json.simple.JSONArray();
+        for (ToolCall c : calls) {
+            org.json.simple.JSONObject o = new org.json.simple.JSONObject();
+            o.put("id", c.getId());
+            o.put("toolName", c.getToolName());
+            o.put("arguments", c.getArguments() == null ? null : c.getArguments().toString());
+            arr.add(o);
+        }
+        res.put("tool_calls", arr);
+        res.put("pending", true);
+        return res;
     }
 
     /** 디버깅/테스트용 내부 대화 기록 접근자. */

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/schema/ResponseSchema.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/schema/ResponseSchema.java
@@ -1,0 +1,93 @@
+package com.smartuxapi.ai.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Provider 중립 구조화 응답(JSON Schema) 래퍼.
+ *
+ * <p>OpenAI Responses API 의 {@code text.format.json_schema} 와
+ * Gemini 의 {@code generationConfig.responseSchema} 두 경로에 동일하게 매핑된다.
+ *
+ * <p>사용 예:
+ * <pre>{@code
+ *   JsonNode schemaNode = ...;  // JSON Schema (object root)
+ *   ResponseSchema schema = ResponseSchema.of("UserProfile", schemaNode);
+ *   chatting.sendPromptWithSchema("Alice, 30", schema);
+ * }</pre>
+ *
+ * <p>제약:
+ * <ul>
+ *   <li>Root 는 {@code type: "object"} 만 지원 (provider 공통).</li>
+ *   <li>OpenAI strict 모드에서는 {@code additionalProperties: false} 가 필수 —
+ *       {@link SchemaBuilder} 경로는 자동 주입, raw JsonNode 경로는 호출자 책임.</li>
+ *   <li>Gemini 는 OpenAI JSON Schema 의 서브셋만 지원 ({@code $ref}, {@code anyOf} 제한).
+ *       초과 시 provider 측 오류가 그대로 전파된다.</li>
+ * </ul>
+ *
+ * @since 0.8.0
+ */
+public final class ResponseSchema {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String name;
+    private final String description;
+    private final JsonNode schema;
+    private final boolean strict;
+
+    private ResponseSchema(String name, String description, JsonNode schema, boolean strict) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("ResponseSchema.name is required");
+        }
+        if (schema == null) {
+            throw new IllegalArgumentException("ResponseSchema.schema is required");
+        }
+        this.name = name;
+        this.description = description;
+        this.schema = schema;
+        this.strict = strict;
+    }
+
+    /**
+     * 이미 만들어진 JsonNode 로부터 구성.
+     *
+     * @param name   schema 이름 (OpenAI 측 식별자로 쓰임, 필수)
+     * @param schema JSON Schema (object root)
+     */
+    public static ResponseSchema of(String name, JsonNode schema) {
+        return new ResponseSchema(name, null, schema, true);
+    }
+
+    /**
+     * 이름/설명/스키마/strict 플래그를 모두 지정.
+     */
+    public static ResponseSchema of(String name, String description, JsonNode schema, boolean strict) {
+        return new ResponseSchema(name, description, schema, strict);
+    }
+
+    /**
+     * 새 {@link SchemaBuilder} 를 object 루트로 시작한다.
+     */
+    public static SchemaBuilder object() {
+        return SchemaBuilder.object();
+    }
+
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+    public JsonNode getSchema() { return schema; }
+    public boolean isStrict() { return strict; }
+
+    /**
+     * 디버깅용 JSON 문자열.
+     */
+    @Override
+    public String toString() {
+        try {
+            return "ResponseSchema{name=" + name + ", strict=" + strict
+                    + ", schema=" + MAPPER.writeValueAsString(schema) + "}";
+        } catch (Exception e) {
+            return "ResponseSchema{name=" + name + ", strict=" + strict + "}";
+        }
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/schema/SchemaBuilder.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/schema/SchemaBuilder.java
@@ -1,0 +1,143 @@
+package com.smartuxapi.ai.schema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * JSON Schema 편의 빌더.
+ *
+ * <p>Object 루트 + 5가지 property 타입(string/integer/boolean/array/nested object) 만 지원.
+ * 범위를 벗어나는 스키마는 raw {@link JsonNode} 를 직접 구성하여 {@link ResponseSchema#of(String, JsonNode)} 에
+ * 전달한다.
+ *
+ * <p>{@link #build()} 가 반환하는 JsonNode 는 {@link ResponseSchema} 와
+ * {@code com.smartuxapi.ai.tools.ToolDefinition.parametersSchema} (T2-b) 에서 공통으로 사용된다.
+ *
+ * <p>Strict 호환을 위해 {@link #build()} 는 object 루트에 자동으로
+ * {@code additionalProperties: false} 를 주입한다.
+ *
+ * @since 0.8.0
+ */
+public final class SchemaBuilder {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ObjectNode properties = MAPPER.createObjectNode();
+    private final Set<String> required = new LinkedHashSet<>();
+    private String description;
+
+    private SchemaBuilder() { /* factory only */ }
+
+    public static SchemaBuilder object() {
+        return new SchemaBuilder();
+    }
+
+    public SchemaBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public SchemaBuilder stringProperty(String name, String description) {
+        ObjectNode prop = MAPPER.createObjectNode();
+        prop.put("type", "string");
+        if (description != null) prop.put("description", description);
+        properties.set(name, prop);
+        return this;
+    }
+
+    public SchemaBuilder integerProperty(String name, String description) {
+        ObjectNode prop = MAPPER.createObjectNode();
+        prop.put("type", "integer");
+        if (description != null) prop.put("description", description);
+        properties.set(name, prop);
+        return this;
+    }
+
+    public SchemaBuilder booleanProperty(String name, String description) {
+        ObjectNode prop = MAPPER.createObjectNode();
+        prop.put("type", "boolean");
+        if (description != null) prop.put("description", description);
+        properties.set(name, prop);
+        return this;
+    }
+
+    /**
+     * 배열 property — 항목 스키마를 중첩 빌더로 지정.
+     *
+     * @param name  property 이름
+     * @param items 항목 스키마 빌더 (object 루트 기준). 단순 타입이 필요하면
+     *              raw JsonNode 경로 사용 권장.
+     */
+    public SchemaBuilder arrayProperty(String name, SchemaBuilder items) {
+        ObjectNode prop = MAPPER.createObjectNode();
+        prop.put("type", "array");
+        prop.set("items", items.build());
+        properties.set(name, prop);
+        return this;
+    }
+
+    /**
+     * 항목 타입이 단순 문자열 배열 — 편의 메서드.
+     */
+    public SchemaBuilder stringArrayProperty(String name, String description) {
+        ObjectNode prop = MAPPER.createObjectNode();
+        prop.put("type", "array");
+        if (description != null) prop.put("description", description);
+        ObjectNode items = MAPPER.createObjectNode();
+        items.put("type", "string");
+        prop.set("items", items);
+        properties.set(name, prop);
+        return this;
+    }
+
+    /**
+     * 중첩 object property.
+     */
+    public SchemaBuilder objectProperty(String name, SchemaBuilder nested) {
+        properties.set(name, nested.build());
+        return this;
+    }
+
+    /**
+     * 필수 property 이름들 추가. 여러 번 호출하면 누적된다.
+     */
+    public SchemaBuilder required(String... names) {
+        if (names != null) required.addAll(Arrays.asList(names));
+        return this;
+    }
+
+    /**
+     * 최종 JSON Schema JsonNode 를 반환. Object 루트 + {@code additionalProperties: false} 자동 포함.
+     * 중첩 object 는 자신의 build() 호출 시 재귀적으로 동일 규칙 적용.
+     */
+    public JsonNode build() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "object");
+        if (description != null) root.put("description", description);
+        root.set("properties", properties);
+        if (!required.isEmpty()) {
+            ArrayNode requiredArray = MAPPER.createArrayNode();
+            for (String n : required) requiredArray.add(n);
+            root.set("required", requiredArray);
+        }
+        root.put("additionalProperties", false);
+        return root;
+    }
+
+    /**
+     * {@link ResponseSchema} 로 래핑하여 반환.
+     *
+     * @param name schema 이름 (OpenAI 식별자)
+     */
+    public ResponseSchema asResponse(String name) {
+        return ResponseSchema.of(name, this.build());
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolCall.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolCall.java
@@ -1,0 +1,42 @@
+package com.smartuxapi.ai.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * LLM 이 생성한 Tool 호출 요청.
+ *
+ * <p>Provider 별 호출 ID 포맷 차이:
+ * <ul>
+ *   <li>OpenAI: {@code call_xxx} (provider 부여)</li>
+ *   <li>Gemini: 클라이언트 생성 (UUID — Gemini API 는 호출 ID 를 응답에 포함하지 않는다)</li>
+ * </ul>
+ *
+ * @since 0.8.0
+ */
+public final class ToolCall {
+
+    private final String id;
+    private final String toolName;
+    private final JsonNode arguments;
+
+    public ToolCall(String id, String toolName, JsonNode arguments) {
+        if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException("ToolCall.id is required");
+        }
+        if (toolName == null || toolName.isEmpty()) {
+            throw new IllegalArgumentException("ToolCall.toolName is required");
+        }
+        this.id = id;
+        this.toolName = toolName;
+        this.arguments = arguments;
+    }
+
+    public String getId() { return id; }
+    public String getToolName() { return toolName; }
+    public JsonNode getArguments() { return arguments; }
+
+    @Override
+    public String toString() {
+        return "ToolCall{id=" + id + ", tool=" + toolName + "}";
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolDefinition.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolDefinition.java
@@ -1,0 +1,42 @@
+package com.smartuxapi.ai.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Tool 정의 — 이름, 설명, 인자 스키마, 실행 핸들러.
+ *
+ * <p>{@code parametersSchema} 는 JSON Schema object 루트이며,
+ * {@link com.smartuxapi.ai.schema.SchemaBuilder} 로 만들거나 raw {@link JsonNode} 로 직접 구성한다.
+ * Structured Output (T2-a) 과 동일 포맷.
+ *
+ * @since 0.8.0
+ */
+public final class ToolDefinition {
+
+    private final String name;
+    private final String description;
+    private final JsonNode parametersSchema;
+    private final ToolHandler handler;
+
+    public ToolDefinition(String name, String description,
+                          JsonNode parametersSchema, ToolHandler handler) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("ToolDefinition.name is required");
+        }
+        if (parametersSchema == null) {
+            throw new IllegalArgumentException("ToolDefinition.parametersSchema is required");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("ToolDefinition.handler is required");
+        }
+        this.name = name;
+        this.description = description == null ? "" : description;
+        this.parametersSchema = parametersSchema;
+        this.handler = handler;
+    }
+
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+    public JsonNode getParametersSchema() { return parametersSchema; }
+    public ToolHandler getHandler() { return handler; }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolHandler.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolHandler.java
@@ -1,0 +1,18 @@
+package com.smartuxapi.ai.tools;
+
+/**
+ * Tool 실행 함수형 인터페이스. LLM 이 호출을 요청했을 때 라이브러리가 invoke 한다.
+ *
+ * <p>구현체는 {@code call.getArguments()} 로 LLM 이 생성한 인자를 받아
+ * 필요한 로직을 수행 후 {@link ToolResult#ok(String, com.fasterxml.jackson.databind.JsonNode)}
+ * 혹은 {@link ToolResult#error(String, String)} 로 돌려준다.
+ *
+ * <p>예외를 던지면 라이브러리가 캐치하여 자동으로
+ * {@link ToolResult#error(String, String)} 로 변환한다.
+ *
+ * @since 0.8.0
+ */
+@FunctionalInterface
+public interface ToolHandler {
+    ToolResult invoke(ToolCall call) throws Exception;
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolRegistry.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolRegistry.java
@@ -1,0 +1,50 @@
+package com.smartuxapi.ai.tools;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Tool 정의 등록소. 이름 기준 유일성 유지, 등록 순서 보존.
+ *
+ * @since 0.8.0
+ */
+public final class ToolRegistry {
+
+    private final Map<String, ToolDefinition> byName = new LinkedHashMap<>();
+
+    /**
+     * 등록. 동일 이름이 있으면 교체된다.
+     */
+    public ToolRegistry register(ToolDefinition def) {
+        if (def == null) throw new IllegalArgumentException("def is required");
+        byName.put(def.getName(), def);
+        return this;
+    }
+
+    public void unregister(String name) {
+        if (name != null) byName.remove(name);
+    }
+
+    public ToolDefinition get(String name) {
+        if (name == null) return null;
+        return byName.get(name);
+    }
+
+    /**
+     * 등록 순서를 유지한 불변 뷰.
+     */
+    public Collection<ToolDefinition> all() {
+        return Collections.unmodifiableCollection(byName.values());
+    }
+
+    public int size() { return byName.size(); }
+    public boolean isEmpty() { return byName.isEmpty(); }
+    public boolean contains(String name) { return byName.containsKey(name); }
+
+    /**
+     * 모든 tool 제거 (테스트/리셋 용).
+     */
+    public void clear() { byName.clear(); }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolResult.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolResult.java
@@ -1,0 +1,67 @@
+package com.smartuxapi.ai.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+/**
+ * Tool 실행 결과.
+ *
+ * <p>설계 제약 (§10 Q5):
+ * <ul>
+ *   <li>{@code output} 직렬화 크기 상한 {@value #MAX_OUTPUT_BYTES} bytes (256KB)</li>
+ *   <li>초과 시 자동 축약 + 경고 메시지 포함 {@link #errorMessage} (실패 아님)</li>
+ * </ul>
+ *
+ * @since 0.8.0
+ */
+public final class ToolResult {
+
+    /** 결과 페이로드 상한 (byte, UTF-8). 256KB. */
+    public static final int MAX_OUTPUT_BYTES = 256 * 1024;
+
+    private final String callId;
+    private final JsonNode output;
+    private final boolean isError;
+    private final String errorMessage;
+
+    private ToolResult(String callId, JsonNode output, boolean isError, String errorMessage) {
+        if (callId == null || callId.isEmpty()) {
+            throw new IllegalArgumentException("ToolResult.callId is required");
+        }
+        this.callId = callId;
+        this.output = output;
+        this.isError = isError;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * 성공 결과 생성.
+     *
+     * @param callId 대응 {@link ToolCall#getId()}
+     * @param output 결과 JSON. null 허용 (빈 결과)
+     */
+    public static ToolResult ok(String callId, JsonNode output) {
+        return new ToolResult(callId, output, false, null);
+    }
+
+    /**
+     * 실패 결과 생성. LLM 은 {@code errorMessage} 를 보고 재시도 판단한다.
+     *
+     * @param callId 대응 {@link ToolCall#getId()}
+     * @param errorMessage 에러 설명
+     */
+    public static ToolResult error(String callId, String errorMessage) {
+        return new ToolResult(callId, TextNode.valueOf(errorMessage == null ? "" : errorMessage),
+                true, errorMessage);
+    }
+
+    public String getCallId() { return callId; }
+    public JsonNode getOutput() { return output; }
+    public boolean isError() { return isError; }
+    public String getErrorMessage() { return errorMessage; }
+
+    @Override
+    public String toString() {
+        return "ToolResult{callId=" + callId + ", isError=" + isError + "}";
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolTurnResult.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/tools/ToolTurnResult.java
@@ -1,0 +1,49 @@
+package com.smartuxapi.ai.tools;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provider 에 대한 한 번의 API 호출 결과. 두 가지 상태 중 하나:
+ * <ul>
+ *   <li><b>최종 응답</b>: {@link #getFinalText()} 가 non-null. {@link #getToolCalls()} 는 비어있음.</li>
+ *   <li><b>Tool 호출 요청</b>: {@link #getToolCalls()} 가 비어있지 않음. {@link #getFinalText()} 는 null.</li>
+ * </ul>
+ *
+ * <p>provider 별 connection 이 응답을 파싱하여 이 객체로 반환하면,
+ * 상위 Chatting 의 auto-loop 가 어떤 경로를 택할지 판단한다.
+ *
+ * @since 0.8.0
+ */
+public final class ToolTurnResult {
+
+    private final String finalText;
+    private final List<ToolCall> toolCalls;
+    private final String rawAssistantPayload;
+
+    private ToolTurnResult(String finalText, List<ToolCall> toolCalls, String rawAssistantPayload) {
+        this.finalText = finalText;
+        this.toolCalls = toolCalls == null ? Collections.emptyList() : Collections.unmodifiableList(toolCalls);
+        this.rawAssistantPayload = rawAssistantPayload;
+    }
+
+    public static ToolTurnResult finalText(String text, String rawAssistantPayload) {
+        return new ToolTurnResult(text, Collections.emptyList(), rawAssistantPayload);
+    }
+
+    public static ToolTurnResult toolCalls(List<ToolCall> calls, String rawAssistantPayload) {
+        return new ToolTurnResult(null, calls, rawAssistantPayload);
+    }
+
+    public String getFinalText() { return finalText; }
+    public List<ToolCall> getToolCalls() { return toolCalls; }
+
+    public boolean hasToolCalls() { return !toolCalls.isEmpty(); }
+    public boolean isFinal() { return finalText != null; }
+
+    /**
+     * provider 가 반환한 원본 assistant payload 의 직렬화 문자열.
+     * 대화 히스토리에 저장하여 다음 턴 재전송에 사용할 때 참조.
+     */
+    public String getRawAssistantPayload() { return rawAssistantPayload; }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/vision/VisionTools.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/vision/VisionTools.java
@@ -1,0 +1,71 @@
+package com.smartuxapi.ai.vision;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartuxapi.ai.ActionQueueHandler;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolResult;
+
+/**
+ * Vision 모듈(T1-b) 을 Tool Use(T2-b) 경로에 등록하기 위한 헬퍼.
+ *
+ * <p>사용 예:
+ * <pre>{@code
+ *   VisionService vision = VisionServiceFactory.createOpenAI(apiKey);
+ *   ToolRegistry tools = new ToolRegistry();
+ *   tools.register(VisionTools.scanImageTool(vision, aqHandler));
+ *
+ *   chatting.sendPromptWithTools(userMsg, tools);
+ *   // LLM 이 필요하다고 판단하면 scanImage 자동 호출 → ActionQueueHandler 에 결과 주입
+ * }</pre>
+ *
+ * @since 0.8.0
+ */
+public final class VisionTools {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private VisionTools() { /* static only */ }
+
+    /**
+     * {@code scanImage} Tool 정의 — 이미지 URL 에서 텍스트 추출.
+     *
+     * <p>ActionQueueHandler 가 null 이 아니면 결과를 자동 주입 (imageUrl 기준 dedupe 는
+     * {@link ActionQueueHandler#addImageScanInfo(ImageScanInfo)} 측에서 수행).
+     *
+     * @param vision VisionService (필수)
+     * @param aqHandler 결과 자동 주입 대상 (null 허용)
+     */
+    public static ToolDefinition scanImageTool(VisionService vision, ActionQueueHandler aqHandler) {
+        if (vision == null) throw new IllegalArgumentException("vision is required");
+
+        JsonNode schema = SchemaBuilder.object()
+                .stringProperty("imageUrl", "스캔할 이미지의 URL")
+                .required("imageUrl")
+                .build();
+
+        return new ToolDefinition(
+                "scanImage",
+                "화면의 이미지 URL 에서 텍스트를 추출한다. alt 가 비어있는 버튼 이미지 등에 사용.",
+                schema,
+                call -> {
+                    JsonNode args = call.getArguments();
+                    String url = args == null ? null : args.path("imageUrl").asText(null);
+                    if (url == null || url.isEmpty()) {
+                        return ToolResult.error(call.getId(), "imageUrl 인자가 비어있음");
+                    }
+                    try {
+                        ImageScanInfo info = vision.scanImage(url);
+                        if (aqHandler != null) {
+                            aqHandler.addImageScanInfo(info);
+                        }
+                        JsonNode outputNode = MAPPER.readTree(info.toJSON().toJSONString());
+                        return ToolResult.ok(call.getId(), outputNode);
+                    } catch (VisionException ve) {
+                        return ToolResult.error(call.getId(),
+                                "VisionException: " + ve.getMessage());
+                    }
+                });
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/gemini/GeminiChattingStructuredOutputTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/gemini/GeminiChattingStructuredOutputTest.java
@@ -1,0 +1,74 @@
+package com.smartuxapi.ai.gemini;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * GeminiChatting 의 Structured Output 경로 단위 테스트.
+ * 네트워크 호출은 Mockito 로 차단.
+ */
+@DisplayName("GeminiChatting — Structured Output 단위 테스트")
+class GeminiChattingStructuredOutputTest {
+
+    @Test
+    @DisplayName("sendPromptWithSchema(msg, null) — sendPrompt 로 위임, structured 키 없음")
+    void testNullSchemaDelegates() throws Exception {
+        GeminiAPIConnection mockConn = mock(GeminiAPIConnection.class);
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(null)))
+                .thenReturn("plain text response");
+
+        GeminiChatting chatting = new GeminiChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("hi", null);
+
+        assertEquals("plain text response", res.get("message"));
+        assertFalse(res.containsKey("structured"));
+    }
+
+    @Test
+    @DisplayName("Schema 지정 — 응답 원문이 JsonNode 로 파싱되어 structured 에 포함")
+    void testSchemaPopulatesStructured() throws Exception {
+        GeminiAPIConnection mockConn = mock(GeminiAPIConnection.class);
+        ResponseSchema schema = SchemaBuilder.object()
+                .stringProperty("city", null)
+                .required("city")
+                .asResponse("Location");
+
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(schema)))
+                .thenReturn("{\"city\":\"Seoul\"}");
+
+        GeminiChatting chatting = new GeminiChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("where?", schema);
+
+        JsonNode structured = (JsonNode) res.get("structured");
+        assertNotNull(structured);
+        assertEquals("Seoul", structured.get("city").asText());
+    }
+
+    @Test
+    @DisplayName("파싱 실패 — structured=null, 예외 없음")
+    void testParseFailureYieldsNull() throws Exception {
+        GeminiAPIConnection mockConn = mock(GeminiAPIConnection.class);
+        ResponseSchema schema = SchemaBuilder.object().stringProperty("x", null).asResponse("Bad");
+
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(schema)))
+                .thenReturn("not a json");
+
+        GeminiChatting chatting = new GeminiChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("x", schema);
+
+        assertTrue(res.containsKey("structured"));
+        assertNull(res.get("structured"));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/openai/ResponsesChattingStructuredOutputTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/openai/ResponsesChattingStructuredOutputTest.java
@@ -1,0 +1,97 @@
+package com.smartuxapi.ai.openai;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ResponsesChatting 의 Structured Output 경로 단위 테스트.
+ * 네트워크 호출은 Mockito 로 차단.
+ */
+@DisplayName("ResponsesChatting — Structured Output 단위 테스트")
+class ResponsesChattingStructuredOutputTest {
+
+    @Test
+    @DisplayName("sendPromptWithSchema(msg, null) — sendPrompt 로 위임, structured 키 없음")
+    void testNullSchemaDelegates() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(null)))
+                .thenReturn("plain text response");
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("hi", null);
+
+        assertEquals("plain text response", res.get("message"));
+        assertFalse(res.containsKey("structured"),
+                "schema=null 경로는 structured 키를 추가하지 않아야 한다");
+    }
+
+    @Test
+    @DisplayName("Schema 지정 — 응답 원문이 JsonNode 로 파싱되어 structured 에 포함")
+    void testSchemaPopulatesStructured() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ResponseSchema schema = SchemaBuilder.object()
+                .stringProperty("name", null)
+                .integerProperty("age", null)
+                .required("name", "age")
+                .asResponse("UserProfile");
+
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(schema)))
+                .thenReturn("{\"name\":\"Alice\",\"age\":30}");
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("who?", schema);
+
+        assertEquals("{\"name\":\"Alice\",\"age\":30}", res.get("message"));
+        JsonNode structured = (JsonNode) res.get("structured");
+        assertNotNull(structured);
+        assertEquals("Alice", structured.get("name").asText());
+        assertEquals(30, structured.get("age").asInt());
+    }
+
+    @Test
+    @DisplayName("파싱 실패 — structured=null, 예외 없음")
+    void testParseFailureYieldsNull() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ResponseSchema schema = SchemaBuilder.object().stringProperty("x", null).asResponse("Bad");
+
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(schema)))
+                .thenReturn("this is not json");
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPromptWithSchema("x", schema);
+
+        assertEquals("this is not json", res.get("message"));
+        assertTrue(res.containsKey("structured"), "schema 지정 시 structured 키는 항상 존재");
+        assertNull(res.get("structured"), "파싱 실패 시 null");
+    }
+
+    @Test
+    @DisplayName("sendPrompt — schema 인자 없이 기존 경로 유지 (structured 키 없음)")
+    void testSendPromptBackwardCompat() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), eq(null)))
+                .thenReturn("ordinary reply");
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        org.json.simple.JSONObject res = chatting.sendPrompt("hi");
+
+        assertEquals("ordinary reply", res.get("message"));
+        assertFalse(res.containsKey("structured"));
+        verify(mockConn, never()).generateContent(any(JSONArray.class));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/openai/ResponsesChattingToolUseTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/openai/ResponsesChattingToolUseTest.java
@@ -1,0 +1,171 @@
+package com.smartuxapi.ai.openai;
+
+import java.util.Arrays;
+
+import org.json.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.schema.SchemaBuilder;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolResult;
+import com.smartuxapi.ai.tools.ToolTurnResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * OpenAI ResponsesChatting 의 Tool Use 경로 Mockito 테스트.
+ */
+@DisplayName("ResponsesChatting — Tool Use 단위 테스트")
+class ResponsesChattingToolUseTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ToolDefinition simpleEchoTool(String name) {
+        return new ToolDefinition(name, "echo",
+                SchemaBuilder.object().stringProperty("value", null).build(),
+                call -> {
+                    ObjectNode out = MAPPER.createObjectNode();
+                    out.put("echo", call.getArguments().path("value").asText("x"));
+                    return ToolResult.ok(call.getId(), out);
+                });
+    }
+
+    @Test
+    @DisplayName("tools=null — sendPrompt 로 위임 (tool_calls 키 없음)")
+    void testNullToolsDelegates() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        when(mockConn.generateContent(any(JSONArray.class), any(CacheStrategy.class), any()))
+                .thenReturn("plain reply");
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject res = chatting.sendPromptWithTools("hi", null);
+
+        assertEquals("plain reply", res.get("message"));
+        assertFalse(res.containsKey("tool_calls"));
+    }
+
+    @Test
+    @DisplayName("1-round auto loop — LLM 이 바로 최종 응답")
+    void testFinalOnFirstRound() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        when(mockConn.generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class)))
+                .thenReturn(ToolTurnResult.finalText("answer", "[]"));
+
+        ToolRegistry tools = new ToolRegistry();
+        tools.register(simpleEchoTool("echo"));
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject res = chatting.sendPromptWithTools("hi", tools);
+
+        assertEquals("answer", res.get("message"));
+        org.json.simple.JSONArray calls = (org.json.simple.JSONArray) res.get("tool_calls");
+        assertTrue(calls.isEmpty());
+        verify(mockConn, times(1))
+                .generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class));
+    }
+
+    @Test
+    @DisplayName("2-round auto loop — tool 호출 실행 후 최종 응답")
+    void testOneToolCallThenFinal() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ToolCall call = new ToolCall("call_1", "echo",
+                MAPPER.readTree("{\"value\":\"hello\"}"));
+        String rawOutputRound1 = "[{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"echo\",\"arguments\":\"{\\\"value\\\":\\\"hello\\\"}\"}]";
+
+        when(mockConn.generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class)))
+                .thenReturn(ToolTurnResult.toolCalls(Arrays.asList(call), rawOutputRound1))
+                .thenReturn(ToolTurnResult.finalText("final-after-tool", "[]"));
+
+        ToolRegistry tools = new ToolRegistry();
+        tools.register(simpleEchoTool("echo"));
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject res = chatting.sendPromptWithTools("please call echo", tools);
+
+        assertEquals("final-after-tool", res.get("message"));
+        org.json.simple.JSONArray calls = (org.json.simple.JSONArray) res.get("tool_calls");
+        assertEquals(1, calls.size(), "1 tool 호출이 기록되어야 함");
+        verify(mockConn, times(2))
+                .generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class));
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 tool 호출 — error ToolResult 로 LLM 에 피드백")
+    void testUnregisteredToolBecomesError() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ToolCall call = new ToolCall("call_x", "nonexistent", MAPPER.createObjectNode());
+        String raw = "[{\"type\":\"function_call\",\"call_id\":\"call_x\",\"name\":\"nonexistent\",\"arguments\":\"{}\"}]";
+
+        when(mockConn.generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class)))
+                .thenReturn(ToolTurnResult.toolCalls(Arrays.asList(call), raw))
+                .thenReturn(ToolTurnResult.finalText("recovered", "[]"));
+
+        ToolRegistry tools = new ToolRegistry();
+        tools.register(simpleEchoTool("other"));
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject res = chatting.sendPromptWithTools("call nonexistent", tools);
+
+        assertEquals("recovered", res.get("message"));
+        org.json.simple.JSONArray calls = (org.json.simple.JSONArray) res.get("tool_calls");
+        assertEquals(1, calls.size());
+        JSONObject exec = (JSONObject) calls.get(0);
+        assertTrue((Boolean) exec.get("isError"), "등록되지 않은 tool 호출은 isError=true");
+    }
+
+    @Test
+    @DisplayName("Manual mode — sendPromptExpectingToolCalls 는 첫 라운드 tool_calls 그대로 반환")
+    void testManualFirstRound() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ToolCall call = new ToolCall("call_2", "echo", MAPPER.readTree("{\"value\":\"x\"}"));
+        String raw = "[{\"type\":\"function_call\",\"call_id\":\"call_2\",\"name\":\"echo\",\"arguments\":\"{}\"}]";
+        when(mockConn.generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class)))
+                .thenReturn(ToolTurnResult.toolCalls(Arrays.asList(call), raw));
+
+        ToolRegistry tools = new ToolRegistry();
+        tools.register(simpleEchoTool("echo"));
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject res = chatting.sendPromptExpectingToolCalls("go", tools);
+
+        assertNull(res.get("message"));
+        assertEquals(Boolean.TRUE, res.get("pending"));
+        org.json.simple.JSONArray arr = (org.json.simple.JSONArray) res.get("tool_calls");
+        assertEquals(1, arr.size());
+    }
+
+    @Test
+    @DisplayName("Manual mode — continueWithToolResults 가 pending 을 끝내고 최종 응답 반환")
+    void testManualContinuation() throws Exception {
+        ResponsesAPIConnection mockConn = mock(ResponsesAPIConnection.class);
+        ToolCall call = new ToolCall("call_3", "echo", MAPPER.readTree("{\"value\":\"x\"}"));
+        String raw = "[{\"type\":\"function_call\",\"call_id\":\"call_3\",\"name\":\"echo\",\"arguments\":\"{}\"}]";
+        when(mockConn.generateContentWithTools(any(JSONArray.class), any(CacheStrategy.class), any(ToolRegistry.class)))
+                .thenReturn(ToolTurnResult.toolCalls(Arrays.asList(call), raw))
+                .thenReturn(ToolTurnResult.finalText("ok!", "[]"));
+
+        ToolRegistry tools = new ToolRegistry();
+        tools.register(simpleEchoTool("echo"));
+
+        ResponsesChatting chatting = new ResponsesChatting(mockConn);
+        JSONObject pending = chatting.sendPromptExpectingToolCalls("go", tools);
+        assertEquals(Boolean.TRUE, pending.get("pending"));
+
+        ToolResult userResult = ToolResult.ok("call_3", MAPPER.readTree("{\"echo\":\"x\"}"));
+        JSONObject done = chatting.continueWithToolResults(Arrays.asList(userResult), tools);
+        assertEquals("ok!", done.get("message"));
+        assertFalse(done.containsKey("pending"));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/schema/ResponseSchemaTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/schema/ResponseSchemaTest.java
@@ -1,0 +1,70 @@
+package com.smartuxapi.ai.schema;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ResponseSchema 단위 테스트")
+class ResponseSchemaTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("of(name, schema) — 기본값 strict=true, description=null")
+    void testOfBasic() throws Exception {
+        JsonNode node = MAPPER.readTree("{\"type\":\"object\"}");
+        ResponseSchema rs = ResponseSchema.of("Foo", node);
+
+        assertEquals("Foo", rs.getName());
+        assertNull(rs.getDescription());
+        assertTrue(rs.isStrict());
+        assertSame(node, rs.getSchema());
+    }
+
+    @Test
+    @DisplayName("of(name, description, schema, strict) — 전체 인자")
+    void testOfFull() throws Exception {
+        JsonNode node = MAPPER.readTree("{\"type\":\"object\"}");
+        ResponseSchema rs = ResponseSchema.of("Foo", "A shape", node, false);
+
+        assertEquals("A shape", rs.getDescription());
+        assertFalse(rs.isStrict());
+    }
+
+    @Test
+    @DisplayName("name 이 null 또는 빈 문자열이면 IllegalArgumentException")
+    void testInvalidName() throws Exception {
+        JsonNode node = MAPPER.readTree("{\"type\":\"object\"}");
+        assertThrows(IllegalArgumentException.class, () -> ResponseSchema.of(null, node));
+        assertThrows(IllegalArgumentException.class, () -> ResponseSchema.of("", node));
+    }
+
+    @Test
+    @DisplayName("schema 가 null 이면 IllegalArgumentException")
+    void testNullSchema() {
+        assertThrows(IllegalArgumentException.class, () -> ResponseSchema.of("Foo", null));
+    }
+
+    @Test
+    @DisplayName("object() 팩토리 — SchemaBuilder 반환")
+    void testObjectFactory() {
+        SchemaBuilder b = ResponseSchema.object();
+        assertNotNull(b);
+        JsonNode node = b.stringProperty("x", null).build();
+        assertEquals("object", node.get("type").asText());
+    }
+
+    @Test
+    @DisplayName("toString — 이름과 strict 포함")
+    void testToString() throws Exception {
+        JsonNode node = MAPPER.readTree("{\"type\":\"object\"}");
+        ResponseSchema rs = ResponseSchema.of("Foo", node);
+        String s = rs.toString();
+        assertTrue(s.contains("Foo"));
+        assertTrue(s.contains("strict=true"));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/schema/SchemaBuilderTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/schema/SchemaBuilderTest.java
@@ -1,0 +1,120 @@
+package com.smartuxapi.ai.schema;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("SchemaBuilder 단위 테스트")
+class SchemaBuilderTest {
+
+    @Test
+    @DisplayName("object 루트 + 기본 필드 — type/properties/additionalProperties=false")
+    void testBasicObject() {
+        JsonNode schema = SchemaBuilder.object()
+                .stringProperty("name", "사용자 이름")
+                .integerProperty("age", "나이")
+                .build();
+
+        assertEquals("object", schema.get("type").asText());
+        assertTrue(schema.has("properties"));
+        assertEquals("string", schema.get("properties").get("name").get("type").asText());
+        assertEquals("integer", schema.get("properties").get("age").get("type").asText());
+        assertFalse(schema.get("additionalProperties").asBoolean(),
+                "strict 호환을 위해 additionalProperties=false 가 자동 주입되어야 한다");
+    }
+
+    @Test
+    @DisplayName("required — 중복 제거 및 순서 유지")
+    void testRequired() {
+        JsonNode schema = SchemaBuilder.object()
+                .stringProperty("a", null)
+                .stringProperty("b", null)
+                .required("a", "b")
+                .required("a")
+                .build();
+
+        JsonNode req = schema.get("required");
+        assertTrue(req.isArray());
+        assertEquals(2, req.size(), "중복된 required 항목은 병합되어야 한다");
+        assertEquals("a", req.get(0).asText());
+        assertEquals("b", req.get(1).asText());
+    }
+
+    @Test
+    @DisplayName("booleanProperty — description 이 null 이면 description 필드 생략")
+    void testBooleanWithoutDescription() {
+        JsonNode schema = SchemaBuilder.object()
+                .booleanProperty("flag", null)
+                .build();
+        JsonNode flag = schema.get("properties").get("flag");
+        assertEquals("boolean", flag.get("type").asText());
+        assertFalse(flag.has("description"));
+    }
+
+    @Test
+    @DisplayName("stringArrayProperty — items.type=string 자동 구성")
+    void testStringArray() {
+        JsonNode schema = SchemaBuilder.object()
+                .stringArrayProperty("tags", "태그 목록")
+                .build();
+        JsonNode tags = schema.get("properties").get("tags");
+        assertEquals("array", tags.get("type").asText());
+        assertEquals("태그 목록", tags.get("description").asText());
+        assertEquals("string", tags.get("items").get("type").asText());
+    }
+
+    @Test
+    @DisplayName("objectProperty — 중첩 object 의 additionalProperties=false 도 주입")
+    void testNestedObject() {
+        JsonNode schema = SchemaBuilder.object()
+                .objectProperty("address",
+                        SchemaBuilder.object()
+                                .stringProperty("city", null)
+                                .required("city"))
+                .build();
+        JsonNode addr = schema.get("properties").get("address");
+        assertEquals("object", addr.get("type").asText());
+        assertFalse(addr.get("additionalProperties").asBoolean());
+    }
+
+    @Test
+    @DisplayName("arrayProperty — items 가 object 인 경우")
+    void testArrayOfObjects() {
+        JsonNode schema = SchemaBuilder.object()
+                .arrayProperty("items",
+                        SchemaBuilder.object()
+                                .stringProperty("sku", null)
+                                .integerProperty("qty", null))
+                .build();
+        JsonNode items = schema.get("properties").get("items");
+        assertEquals("array", items.get("type").asText());
+        assertEquals("object", items.get("items").get("type").asText());
+        assertEquals("string", items.get("items").get("properties").get("sku").get("type").asText());
+    }
+
+    @Test
+    @DisplayName("asResponse — ResponseSchema 로 래핑")
+    void testAsResponse() {
+        ResponseSchema rs = SchemaBuilder.object()
+                .stringProperty("x", null)
+                .required("x")
+                .asResponse("MyShape");
+
+        assertEquals("MyShape", rs.getName());
+        assertTrue(rs.isStrict(), "기본 strict=true");
+        assertEquals("object", rs.getSchema().get("type").asText());
+    }
+
+    @Test
+    @DisplayName("description() — root 에 description 주입")
+    void testRootDescription() {
+        JsonNode schema = SchemaBuilder.object()
+                .description("사용자 프로필")
+                .stringProperty("name", null)
+                .build();
+        assertEquals("사용자 프로필", schema.get("description").asText());
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolCallResultTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolCallResultTest.java
@@ -1,0 +1,73 @@
+package com.smartuxapi.ai.tools;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ToolCall / ToolResult 단위 테스트")
+class ToolCallResultTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("ToolCall — 기본 필드")
+    void testToolCall() throws Exception {
+        ToolCall c = new ToolCall("call_1", "scanImage", MAPPER.readTree("{\"imageUrl\":\"u\"}"));
+        assertEquals("call_1", c.getId());
+        assertEquals("scanImage", c.getToolName());
+        assertEquals("u", c.getArguments().get("imageUrl").asText());
+    }
+
+    @Test
+    @DisplayName("ToolCall — id/name 빈 값이면 IllegalArgumentException")
+    void testToolCallValidation() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolCall(null, "x", MAPPER.createObjectNode()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolCall("", "x", MAPPER.createObjectNode()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolCall("id", null, MAPPER.createObjectNode()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolCall("id", "", MAPPER.createObjectNode()));
+    }
+
+    @Test
+    @DisplayName("ToolResult.ok — isError=false, output 유지")
+    void testOk() {
+        ToolResult r = ToolResult.ok("call_1", TextNode.valueOf("done"));
+        assertFalse(r.isError());
+        assertEquals("call_1", r.getCallId());
+        assertEquals("done", r.getOutput().asText());
+        assertNull(r.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("ToolResult.error — isError=true, output 에도 에러 메시지 포함")
+    void testError() {
+        ToolResult r = ToolResult.error("call_1", "boom");
+        assertTrue(r.isError());
+        assertEquals("boom", r.getErrorMessage());
+        assertEquals("boom", r.getOutput().asText());
+    }
+
+    @Test
+    @DisplayName("ToolResult — callId 필수")
+    void testCallIdRequired() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ToolResult.ok(null, MAPPER.createObjectNode()));
+        assertThrows(IllegalArgumentException.class,
+                () -> ToolResult.ok("", MAPPER.createObjectNode()));
+        assertThrows(IllegalArgumentException.class,
+                () -> ToolResult.error(null, "msg"));
+    }
+
+    @Test
+    @DisplayName("MAX_OUTPUT_BYTES 값 확인 (256KB)")
+    void testMaxOutputBytes() {
+        assertEquals(256 * 1024, ToolResult.MAX_OUTPUT_BYTES);
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolRegistryTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolRegistryTest.java
@@ -1,0 +1,92 @@
+package com.smartuxapi.ai.tools;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.smartuxapi.ai.schema.SchemaBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ToolRegistry/ToolDefinition 단위 테스트")
+class ToolRegistryTest {
+
+    private ToolDefinition def(String name) {
+        return new ToolDefinition(
+                name,
+                "desc of " + name,
+                SchemaBuilder.object().stringProperty("x", null).build(),
+                call -> ToolResult.ok(call.getId(), null));
+    }
+
+    @Test
+    @DisplayName("register / get / contains / size / isEmpty / all 기본 동작")
+    void testBasicOps() {
+        ToolRegistry reg = new ToolRegistry();
+        assertTrue(reg.isEmpty());
+        assertEquals(0, reg.size());
+
+        reg.register(def("foo"));
+        reg.register(def("bar"));
+
+        assertEquals(2, reg.size());
+        assertFalse(reg.isEmpty());
+        assertTrue(reg.contains("foo"));
+        assertNotNull(reg.get("foo"));
+        assertNull(reg.get("nonexistent"));
+        assertEquals(2, reg.all().size());
+    }
+
+    @Test
+    @DisplayName("등록 순서 유지 — all() 반환 Collection")
+    void testInsertionOrder() {
+        ToolRegistry reg = new ToolRegistry();
+        reg.register(def("c"));
+        reg.register(def("a"));
+        reg.register(def("b"));
+
+        java.util.Iterator<ToolDefinition> it = reg.all().iterator();
+        assertEquals("c", it.next().getName());
+        assertEquals("a", it.next().getName());
+        assertEquals("b", it.next().getName());
+    }
+
+    @Test
+    @DisplayName("동일 이름 재등록 시 교체")
+    void testReplace() {
+        ToolRegistry reg = new ToolRegistry();
+        reg.register(def("foo"));
+        ToolDefinition old = reg.get("foo");
+        reg.register(def("foo"));
+        ToolDefinition newDef = reg.get("foo");
+        assertNotSame(old, newDef);
+        assertEquals(1, reg.size());
+    }
+
+    @Test
+    @DisplayName("unregister / clear")
+    void testRemoval() {
+        ToolRegistry reg = new ToolRegistry();
+        reg.register(def("foo"));
+        reg.register(def("bar"));
+
+        reg.unregister("foo");
+        assertFalse(reg.contains("foo"));
+        assertEquals(1, reg.size());
+
+        reg.clear();
+        assertTrue(reg.isEmpty());
+    }
+
+    @Test
+    @DisplayName("register(null) / null name / null handler — IllegalArgumentException")
+    void testValidation() {
+        ToolRegistry reg = new ToolRegistry();
+        assertThrows(IllegalArgumentException.class, () -> reg.register(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolDefinition(null, "", SchemaBuilder.object().build(), c -> null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolDefinition("x", "", null, c -> null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolDefinition("x", "", SchemaBuilder.object().build(), null));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolTurnResultTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/tools/ToolTurnResultTest.java
@@ -1,0 +1,45 @@
+package com.smartuxapi.ai.tools;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ToolTurnResult 단위 테스트")
+class ToolTurnResultTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("finalText — isFinal=true, hasToolCalls=false")
+    void testFinal() {
+        ToolTurnResult r = ToolTurnResult.finalText("done", "[]");
+        assertTrue(r.isFinal());
+        assertFalse(r.hasToolCalls());
+        assertEquals("done", r.getFinalText());
+        assertTrue(r.getToolCalls().isEmpty());
+    }
+
+    @Test
+    @DisplayName("toolCalls — isFinal=false, hasToolCalls=true, 리스트 불변")
+    void testToolCalls() throws Exception {
+        ToolCall c = new ToolCall("id1", "foo", MAPPER.createObjectNode());
+        ToolTurnResult r = ToolTurnResult.toolCalls(Arrays.asList(c), "raw");
+        assertFalse(r.isFinal());
+        assertTrue(r.hasToolCalls());
+        assertNull(r.getFinalText());
+        assertEquals(1, r.getToolCalls().size());
+        assertThrows(UnsupportedOperationException.class, () -> r.getToolCalls().add(c));
+    }
+
+    @Test
+    @DisplayName("rawAssistantPayload — 그대로 보관")
+    void testRaw() {
+        ToolTurnResult r = ToolTurnResult.finalText("t", "raw-payload");
+        assertEquals("raw-payload", r.getRawAssistantPayload());
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/vision/VisionToolsTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/vision/VisionToolsTest.java
@@ -1,0 +1,89 @@
+package com.smartuxapi.ai.vision;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartuxapi.ai.ActionQueueHandler;
+import com.smartuxapi.ai.tools.ToolCall;
+import com.smartuxapi.ai.tools.ToolDefinition;
+import com.smartuxapi.ai.tools.ToolResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@DisplayName("VisionTools.scanImageTool 단위 테스트")
+class VisionToolsTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("정상 경로 — vision.scanImage 결과가 ToolResult output 으로 반환")
+    void testHappyPath() throws Exception {
+        VisionService vision = mock(VisionService.class);
+        ImageScanInfo info = new ImageScanInfo("https://x/1.png", "button text", 0.9, "gpt-4o");
+        when(vision.scanImage("https://x/1.png")).thenReturn(info);
+
+        ToolDefinition def = VisionTools.scanImageTool(vision, null);
+        assertEquals("scanImage", def.getName());
+
+        ToolCall call = new ToolCall("c1", "scanImage",
+                MAPPER.readTree("{\"imageUrl\":\"https://x/1.png\"}"));
+        ToolResult result = def.getHandler().invoke(call);
+
+        assertFalse(result.isError());
+        assertEquals("https://x/1.png", result.getOutput().get("imageUrl").asText());
+        assertEquals("button text", result.getOutput().get("extractedText").asText());
+    }
+
+    @Test
+    @DisplayName("ActionQueueHandler 주입 시 addImageScanInfo 자동 호출")
+    void testActionQueueInjection() throws Exception {
+        VisionService vision = mock(VisionService.class);
+        ActionQueueHandler aq = mock(ActionQueueHandler.class);
+        ImageScanInfo info = new ImageScanInfo("u", "t", 1.0, null);
+        when(vision.scanImage("u")).thenReturn(info);
+
+        ToolDefinition def = VisionTools.scanImageTool(vision, aq);
+        ToolCall call = new ToolCall("c", "scanImage", MAPPER.readTree("{\"imageUrl\":\"u\"}"));
+        def.getHandler().invoke(call);
+
+        verify(aq).addImageScanInfo(info);
+    }
+
+    @Test
+    @DisplayName("imageUrl 누락 — error ToolResult")
+    void testMissingUrl() throws Exception {
+        VisionService vision = mock(VisionService.class);
+        ToolDefinition def = VisionTools.scanImageTool(vision, null);
+
+        ToolCall call = new ToolCall("c", "scanImage", MAPPER.readTree("{}"));
+        ToolResult r = def.getHandler().invoke(call);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorMessage().contains("imageUrl"));
+    }
+
+    @Test
+    @DisplayName("VisionException — error ToolResult 로 변환")
+    void testVisionExceptionToError() throws Exception {
+        VisionService vision = mock(VisionService.class);
+        when(vision.scanImage(any())).thenThrow(new VisionException("boom"));
+
+        ToolDefinition def = VisionTools.scanImageTool(vision, null);
+        ToolCall call = new ToolCall("c", "scanImage", MAPPER.readTree("{\"imageUrl\":\"u\"}"));
+        ToolResult r = def.getHandler().invoke(call);
+
+        assertTrue(r.isError());
+        assertTrue(r.getErrorMessage().contains("VisionException"));
+    }
+
+    @Test
+    @DisplayName("vision=null — IllegalArgumentException")
+    void testNullVision() {
+        assertThrows(IllegalArgumentException.class,
+                () -> VisionTools.scanImageTool(null, null));
+    }
+}


### PR DESCRIPTION
## Summary
- **T2-a Structured Output**: Provider 중립 JSON Schema 강제 응답 API (`com.smartuxapi.ai.schema`)
- **T2-b Tool Use / Function Calling**: Provider 중립 자동 루프 + 수동 dispatch (`com.smartuxapi.ai.tools`)
- **VisionTools.scanImageTool**: T1-b × T2-b 통합 — Vision 을 Tool 로 감싸 LLM 이 자동 호출 가능

## Changes
- `lib/build.gradle.kts` version `0.7.0` → `0.8.0`
- `CHANGELOG.md` [0.8.0] 엔트리 추가 (Added / Changed)
- `Chatting.sendPromptWithSchema`, `sendPromptWithTools`, `sendPromptExpectingToolCalls`, `continueWithToolResults` — 모두 default 메서드 (하위 호환)
- OpenAI/Gemini `ConversationHistory` 에 tool_call / tool_result 아이템 지원

## Test plan
- [x] 358 tests / 338 pass / 20 skip (integration — API 키 요구) / **0 fail**
- [x] Gradle build 성공 (경고 없음)
- [x] 로컬 배포 완료 (`doribox/libs/` 에 `smart-ux-api-0.8.0.jar`)
- [ ] doribox 소비처 연동 확인 (머지 후 수동)

## Notes
- 캐시/비전 기능과 조합 가능 — 모두 opt-in, 미사용 경로 무영향
- Tool Use 안전장치: max_tool_rounds=5, 256KB 상한, 미등록 tool 호출 → `ToolResult.error`
- 기존 `sendPrompt(msg)` 경로는 불변 — smuxapi-demo / doribox 기존 호출부 무수정 동작
- 가이드: `doc/structured-output-guide.md`, `doc/tool-use-guide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)