### PR TITLE
Release v0.9.0 — Embeddings API

### DIFF
--- a/smart-ux-api/CHANGELOG.md
+++ b/smart-ux-api/CHANGELOG.md
@@ -9,6 +9,23 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.9.0] - 2026-04-22
+
+### Added
+- **Embeddings API** (Provider 중립 텍스트 임베딩 — T3-a)
+  - `com.smartuxapi.ai.embedding`: `EmbeddingService`, `EmbeddingResult`, `EmbeddingException`, `EmbeddingServiceFactory`, `Embeddings` 유틸
+  - OpenAI 구현: `text-embedding-3-small` (1536, 기본) / `text-embedding-3-large` (3072) / `ada-002` (legacy)
+  - Gemini 구현: `text-embedding-004` (768, 기본) — `batchEmbedContents` REST 엔드포인트
+  - `embed(text)` 단일 + `embedBatch(List<String>)` 배치 — 한 번의 API 호출로 여러 텍스트 처리
+  - `Embeddings` 유틸: `cosineSimilarity`, `argmax`, `topK`, `normalize` — 0-벡터 NaN 방지
+  - `EmbeddingServiceFactory.createOpenAI[FromEnv]` / `createGemini[FromEnv]`
+  - 가이드: `doc/embeddings-guide.md`
+- 총 테스트 수: 384 → 444 (+60 이중 집계 포함, 실제 +30건)
+
+### Notes
+- T3-b (Cross-provider Fallback + Cost Telemetry) 는 v0.9.1 로 이관 — 별도 설계 스케치 `20260422_fallback_telemetry_design_sketch.md` 준비됨
+
+---
 ## [0.8.1] - 2026-04-22
 
 ### Added

--- a/smart-ux-api/doc/embeddings-guide.md
+++ b/smart-ux-api/doc/embeddings-guide.md
@@ -1,0 +1,124 @@
+# Embeddings Guide (v0.9.0+)
+
+smart-ux-api v0.9.0 은 **Provider 중립 임베딩 API** 를 제공합니다.
+텍스트를 벡터로 변환하여 UI Object Map 의미 검색, 사용자 의도 매칭 등에 활용할 수 있습니다.
+
+---
+
+## 1. 핵심 API
+
+| API | 설명 |
+|-----|------|
+| `EmbeddingServiceFactory.createOpenAI(apiKey[, model])` | OpenAI 임베딩 서비스 (기본 `text-embedding-3-small`) |
+| `EmbeddingServiceFactory.createGemini(apiKey[, model])` | Gemini 임베딩 서비스 (기본 `text-embedding-004`) |
+| `EmbeddingService.embed(text)` | 단일 텍스트 → `float[]` |
+| `EmbeddingService.embedBatch(texts)` | 여러 텍스트 → `EmbeddingResult` |
+| `Embeddings.cosineSimilarity(a, b)` | 코사인 유사도 |
+| `Embeddings.argmax(query, candidates)` | 가장 유사한 후보 인덱스 |
+| `Embeddings.topK(query, candidates, k)` | 상위 k 후보 인덱스 (내림차순) |
+| `Embeddings.normalize(v)` | L2 정규화 |
+
+---
+
+## 2. 벡터 차원 (provider/model 의존)
+
+| Provider | Model | Dimension |
+|----------|-------|-----------|
+| OpenAI | `text-embedding-3-small` (기본) | 1536 |
+| OpenAI | `text-embedding-3-large` | 3072 |
+| OpenAI | `text-embedding-ada-002` (legacy) | 1536 |
+| Gemini | `text-embedding-004` (기본) | 768 |
+| Gemini | `embedding-001` (legacy) | 768 |
+
+> **차원 혼합 금지** — 한 프로젝트에서는 한 provider 의 벡터만 사용.
+
+---
+
+## 3. 기본 사용 — UI Object Map 의미 검색
+
+```java
+import com.smartuxapi.ai.embedding.*;
+
+EmbeddingService em = EmbeddingServiceFactory.createOpenAI(apiKey);
+
+// 1. UI 라벨 배치 임베딩 (한 번만 수행, 캐시)
+List<String> uiLabels = Arrays.asList("취소", "확인", "주문하기", "뒤로가기");
+EmbeddingResult uiMap = em.embedBatch(uiLabels);
+
+// 2. 사용자 입력으로부터 가장 가까운 라벨 찾기
+float[] queryVec = em.embed("돌아가고 싶어");
+int idx = Embeddings.argmax(queryVec, uiMap);
+System.out.println("매칭된 UI: " + uiLabels.get(idx));   // "뒤로가기"
+```
+
+---
+
+## 4. 상위 k 후보 검색
+
+```java
+float[] query = em.embed("취소하고 나가고 싶어");
+int[] top3 = Embeddings.topK(query, uiMap, 3);
+for (int i : top3) {
+    float score = Embeddings.cosineSimilarity(query, uiMap.get(i));
+    System.out.printf("%s (score=%.3f)%n", uiLabels.get(i), score);
+}
+```
+
+---
+
+## 5. 환경 변수 팩토리
+
+```java
+// OPENAI_API_KEY 환경변수 or openai.api.key 시스템 프로퍼티
+EmbeddingService em = EmbeddingServiceFactory.createOpenAIFromEnv();
+if (!em.isEnabled()) {
+    // fallback 로직
+}
+```
+
+---
+
+## 6. Provider 매핑
+
+### OpenAI
+- 엔드포인트: `POST https://api.openai.com/v1/embeddings`
+- 요청: `{ model, input: [...], encoding_format: "float" }`
+- 응답: `{ data: [{ embedding: [...] }], usage: { prompt_tokens } }`
+- 배치 가능 — 한 번의 호출로 여러 텍스트 처리 (권장)
+
+### Gemini
+- 엔드포인트: `POST /v1beta/models/{model}:batchEmbedContents?key={apiKey}`
+- 요청: `{ requests: [{ model: "models/...", content: { parts: [{ text }] } }] }`
+- 응답: `{ embeddings: [{ values: [...] }] }`
+- `text-embedding-004` 는 무료 tier 포함 (rate limit 있음)
+- **유의**: Gemini batchEmbedContents 응답은 토큰 사용량을 포함하지 않음 — `EmbeddingResult.getPromptTokens()` 은 항상 0
+
+---
+
+## 7. 제약 / 주의
+
+- **차원 mismatch**: OpenAI 1536 과 Gemini 768 벡터를 섞어 `cosineSimilarity` 호출하면 `IllegalArgumentException`. 프로젝트 내에서 **한 provider 선택**.
+- **0-벡터**: `cosineSimilarity(zero, v)` 는 `0.0` 반환 (NaN 방지). 실제 API 는 0-벡터를 거의 반환하지 않음.
+- **빈 입력**: `embed("")` 또는 `embedBatch([])` 는 `EmbeddingException` (네트워크 호출 전 fail-fast).
+- **입력 크기**: OpenAI 는 텍스트당 최대 약 8192 토큰. 초과하면 API 가 거부. 사전 분할 필요.
+- **토큰 비용**:
+  - OpenAI `text-embedding-3-small`: $0.02 / 1M 입력 토큰
+  - OpenAI `text-embedding-3-large`: $0.13 / 1M
+  - Gemini `text-embedding-004`: 무료 tier + paid plan 확인 필요
+
+---
+
+## 8. T3-b 예고 (v0.9.1)
+
+- Cross-provider Fallback + Cost Telemetry 도입 예정.
+- Embedding 호출에도 fallback 적용 가능 (설계 스케치 §6).
+
+---
+
+## 9. 관련 문서
+
+- `caching-guide.md` — Prompt Caching (v0.7.0)
+- `vision-guide.md` — Vision API (v0.7.0) + Gemini 지원 (v0.8.1)
+- `structured-output-guide.md` — Structured Output (v0.8.0)
+- `tool-use-guide.md` — Tool Use (v0.8.0)
+- `doc/tasks/20260422_embeddings_design_sketch.md` — 설계 스케치 v1.0 (로컬)

--- a/smart-ux-api/lib/build.gradle.kts
+++ b/smart-ux-api/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.smartuxapi.ai"  // 그룹 ID 설정
-version = "0.8.1"            // 프로젝트 버전 설정
+version = "0.9.0"            // 프로젝트 버전 설정
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingException.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingException.java
@@ -1,0 +1,21 @@
+package com.smartuxapi.ai.embedding;
+
+/**
+ * Embedding API 호출 실패를 나타내는 checked exception.
+ *
+ * <p>Tool Use 의 handler 에서 catch 하여 {@code ToolResult.error} 로 변환하는 용도로도 사용 가능.
+ *
+ * @since 0.9.0
+ */
+public class EmbeddingException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public EmbeddingException(String message) {
+        super(message);
+    }
+
+    public EmbeddingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingResult.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingResult.java
@@ -1,0 +1,54 @@
+package com.smartuxapi.ai.embedding;
+
+/**
+ * 배치 임베딩 호출 결과.
+ *
+ * <p>벡터는 {@code float[][]} 로 {@code [batch_size][dimension]} 레이아웃.
+ * 원본 배열은 생성자에서 방어 복사하지 않는다 — 호출자가 수정하면 내부 상태에 영향.
+ * 읽기 전용 사용을 전제로 한다.
+ *
+ * @since 0.9.0
+ */
+public final class EmbeddingResult {
+
+    private final float[][] vectors;
+    private final int dimension;
+    private final String model;
+    private final int promptTokens;
+
+    /**
+     * @param vectors [batch_size][dimension] — 비어있으면 안 됨
+     * @param model 사용된 모델 식별자 (provider 별 naming)
+     * @param promptTokens 입력 토큰 수 (미제공 시 0)
+     */
+    public EmbeddingResult(float[][] vectors, String model, int promptTokens) {
+        if (vectors == null || vectors.length == 0) {
+            throw new IllegalArgumentException("vectors must not be empty");
+        }
+        this.vectors = vectors;
+        this.dimension = vectors[0].length;
+        this.model = model == null ? "" : model;
+        this.promptTokens = Math.max(0, promptTokens);
+    }
+
+    /** i 번째 벡터 (참조 반환). */
+    public float[] get(int i) {
+        return vectors[i];
+    }
+
+    /** 내부 배열 참조. */
+    public float[][] getVectors() {
+        return vectors;
+    }
+
+    public int size() { return vectors.length; }
+    public int getDimension() { return dimension; }
+    public String getModel() { return model; }
+    public int getPromptTokens() { return promptTokens; }
+
+    @Override
+    public String toString() {
+        return "EmbeddingResult{size=" + size() + ", dim=" + dimension
+                + ", model=" + model + ", promptTokens=" + promptTokens + "}";
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingService.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingService.java
@@ -1,0 +1,56 @@
+package com.smartuxapi.ai.embedding;
+
+import java.util.List;
+
+/**
+ * 텍스트 임베딩 서비스 인터페이스 — provider 중립.
+ *
+ * <p>구현체는 상태 비유지(stateless) 여야 한다. Vision / Tool Use 와 동일한 정책.
+ *
+ * <p>벡터 차원은 provider / model 의존:
+ * <ul>
+ *   <li>OpenAI {@code text-embedding-3-small} — 1536</li>
+ *   <li>OpenAI {@code text-embedding-3-large} — 3072</li>
+ *   <li>Gemini {@code text-embedding-004} — 768</li>
+ * </ul>
+ *
+ * <p>여러 provider 를 혼합하여 저장/검색하면 차원 mismatch 가 발생하므로, 한 프로젝트에서
+ * 는 한 provider 의 벡터만 사용한다.
+ *
+ * @since 0.9.0
+ */
+public interface EmbeddingService {
+
+    /**
+     * 단일 텍스트 임베딩 — {@link #embedBatch(List)} 의 편의 래퍼.
+     *
+     * @param text 입력 텍스트 (null/empty 불가)
+     * @return 벡터 (차원 = {@link #getDimension()})
+     * @throws EmbeddingException API 호출 실패 등
+     */
+    float[] embed(String text) throws EmbeddingException;
+
+    /**
+     * 배치 임베딩 — 한 번의 API 호출로 여러 텍스트 처리.
+     *
+     * @param texts 입력 텍스트 리스트 (null/empty 불가)
+     * @return 전체 결과 (배열 + 모델 + 토큰)
+     * @throws EmbeddingException API 호출 실패 등
+     */
+    EmbeddingResult embedBatch(List<String> texts) throws EmbeddingException;
+
+    /**
+     * 서비스 활성화 여부 — API 키가 유효하게 설정되어 있으면 true.
+     */
+    boolean isEnabled();
+
+    /**
+     * 구성된 모델의 벡터 차원 수 (네트워크 호출 없이 메타데이터 반환).
+     */
+    int getDimension();
+
+    /**
+     * 사용 중인 모델 식별자.
+     */
+    String getModel();
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingServiceFactory.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/EmbeddingServiceFactory.java
@@ -1,0 +1,60 @@
+package com.smartuxapi.ai.embedding;
+
+import com.smartuxapi.ai.embedding.impl.GeminiEmbeddingService;
+import com.smartuxapi.ai.embedding.impl.OpenAiEmbeddingService;
+
+/**
+ * {@link EmbeddingService} 인스턴스 팩토리.
+ *
+ * <p>기본 모델:
+ * <ul>
+ *   <li>OpenAI — {@code text-embedding-3-small} (1536 차원)</li>
+ *   <li>Gemini — {@code text-embedding-004} (768 차원)</li>
+ * </ul>
+ *
+ * @since 0.9.0
+ */
+public final class EmbeddingServiceFactory {
+
+    private EmbeddingServiceFactory() {}
+
+    public static EmbeddingService createOpenAI(String apiKey) {
+        return new OpenAiEmbeddingService(apiKey);
+    }
+
+    public static EmbeddingService createOpenAI(String apiKey, String model) {
+        return new OpenAiEmbeddingService(apiKey, model);
+    }
+
+    /**
+     * 환경 변수에서 API 키를 읽어 OpenAI Embedding 서비스 생성.
+     * 조회 순서: {@code OPENAI_API_KEY} 환경변수 → {@code openai.api.key} 시스템 프로퍼티.
+     */
+    public static EmbeddingService createOpenAIFromEnv() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            apiKey = System.getProperty("openai.api.key");
+        }
+        return new OpenAiEmbeddingService(apiKey);
+    }
+
+    public static EmbeddingService createGemini(String apiKey) {
+        return new GeminiEmbeddingService(apiKey);
+    }
+
+    public static EmbeddingService createGemini(String apiKey, String model) {
+        return new GeminiEmbeddingService(apiKey, model);
+    }
+
+    /**
+     * 환경 변수에서 API 키를 읽어 Gemini Embedding 서비스 생성.
+     * 조회 순서: {@code GEMINI_API_KEY} 환경변수 → {@code gemini.api.key} 시스템 프로퍼티.
+     */
+    public static EmbeddingService createGeminiFromEnv() {
+        String apiKey = System.getenv("GEMINI_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            apiKey = System.getProperty("gemini.api.key");
+        }
+        return new GeminiEmbeddingService(apiKey);
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/Embeddings.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/Embeddings.java
@@ -1,0 +1,124 @@
+package com.smartuxapi.ai.embedding;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ * 벡터 유사도 유틸리티.
+ *
+ * <p>모든 메서드는 입력 벡터가 같은 차원임을 가정 — 다르면 {@link IllegalArgumentException}.
+ *
+ * @since 0.9.0
+ */
+public final class Embeddings {
+
+    private Embeddings() {}
+
+    /**
+     * 코사인 유사도 — 범위 [-1, 1]. 두 벡터 중 하나라도 0-벡터면 0.0 반환 (NaN 방지).
+     */
+    public static float cosineSimilarity(float[] a, float[] b) {
+        checkDim(a, b);
+        double dot = 0.0, na = 0.0, nb = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            dot += (double) a[i] * b[i];
+            na += (double) a[i] * a[i];
+            nb += (double) b[i] * b[i];
+        }
+        if (na == 0.0 || nb == 0.0) return 0.0f;
+        return (float) (dot / (Math.sqrt(na) * Math.sqrt(nb)));
+    }
+
+    /**
+     * query 와 가장 유사한 candidate 의 인덱스.
+     *
+     * @throws IllegalArgumentException candidates 가 비어있거나 차원 불일치
+     */
+    public static int argmax(float[] query, EmbeddingResult candidates) {
+        if (candidates == null || candidates.size() == 0) {
+            throw new IllegalArgumentException("candidates must not be empty");
+        }
+        int bestIdx = 0;
+        float bestScore = -Float.MAX_VALUE;
+        for (int i = 0; i < candidates.size(); i++) {
+            float s = cosineSimilarity(query, candidates.get(i));
+            if (s > bestScore) {
+                bestScore = s;
+                bestIdx = i;
+            }
+        }
+        return bestIdx;
+    }
+
+    /**
+     * 상위 k 개 후보 인덱스 (점수 내림차순). k 가 candidates 크기보다 크면 전체 반환.
+     */
+    public static int[] topK(float[] query, EmbeddingResult candidates, int k) {
+        if (candidates == null || candidates.size() == 0) {
+            throw new IllegalArgumentException("candidates must not be empty");
+        }
+        if (k <= 0) throw new IllegalArgumentException("k must be positive");
+        int effectiveK = Math.min(k, candidates.size());
+
+        // min-heap of size K — keeps K largest; entry = [-1 for unused, ...]
+        PriorityQueue<int[]> heap = new PriorityQueue<>(
+                effectiveK,
+                Comparator.comparingDouble(entry -> Float.intBitsToFloat(entry[1])));
+
+        for (int i = 0; i < candidates.size(); i++) {
+            float s = cosineSimilarity(query, candidates.get(i));
+            int[] entry = new int[]{i, Float.floatToRawIntBits(s)};
+            if (heap.size() < effectiveK) {
+                heap.offer(entry);
+            } else {
+                float smallest = Float.intBitsToFloat(heap.peek()[1]);
+                if (s > smallest) {
+                    heap.poll();
+                    heap.offer(entry);
+                }
+            }
+        }
+
+        // heap → 내림차순 배열
+        int[] result = new int[heap.size()];
+        float[] scores = new float[heap.size()];
+        int cursor = heap.size() - 1;
+        while (!heap.isEmpty()) {
+            int[] entry = heap.poll();
+            result[cursor] = entry[0];
+            scores[cursor] = Float.intBitsToFloat(entry[1]);
+            cursor--;
+        }
+        // 점수가 동률일 때 heap 에서 꺼내는 순서가 보장되지 않으므로 정렬로 확정
+        // (result 와 scores 를 zip 정렬)
+        Integer[] idx = new Integer[result.length];
+        for (int i = 0; i < idx.length; i++) idx[i] = i;
+        java.util.Arrays.sort(idx, (x, y) -> Float.compare(scores[y], scores[x]));
+        int[] sorted = new int[result.length];
+        for (int i = 0; i < idx.length; i++) sorted[i] = result[idx[i]];
+        return sorted;
+    }
+
+    /**
+     * L2 normalize — in-place 가 아닌 새 배열 반환. 이미 정규화된 벡터끼리는 코사인 = dot.
+     */
+    public static float[] normalize(float[] v) {
+        if (v == null) throw new IllegalArgumentException("v must not be null");
+        double n = 0.0;
+        for (float x : v) n += (double) x * x;
+        if (n == 0.0) return v.clone();
+        float norm = (float) Math.sqrt(n);
+        float[] out = new float[v.length];
+        for (int i = 0; i < v.length; i++) out[i] = v[i] / norm;
+        return out;
+    }
+
+    private static void checkDim(float[] a, float[] b) {
+        if (a == null || b == null) throw new IllegalArgumentException("vector must not be null");
+        if (a.length != b.length) {
+            throw new IllegalArgumentException(
+                    "dimension mismatch: " + a.length + " vs " + b.length);
+        }
+        if (a.length == 0) throw new IllegalArgumentException("vector must not be empty");
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingService.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingService.java
@@ -1,0 +1,185 @@
+package com.smartuxapi.ai.embedding.impl;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.smartuxapi.ai.embedding.EmbeddingException;
+import com.smartuxapi.ai.embedding.EmbeddingResult;
+import com.smartuxapi.ai.embedding.EmbeddingService;
+
+/**
+ * Google Gemini 기반 EmbeddingService 구현체.
+ *
+ * <p>엔드포인트: {@code POST /v1beta/models/{model}:batchEmbedContents?key={apiKey}}.
+ * 기본 모델 {@code text-embedding-004} (768 차원).
+ *
+ * <p>Gemini 배치 요청 포맷 ({@code batchEmbedContents}) 은 각 request 에 model 경로가
+ * 포함되어야 한다 (URL 의 {model} 과 동일):
+ * <pre>{
+ *   "requests": [
+ *     { "model": "models/text-embedding-004", "content": { "parts": [{"text": "..."}] } },
+ *     ...
+ *   ]
+ * }</pre>
+ *
+ * @since 0.9.0
+ */
+public class GeminiEmbeddingService implements EmbeddingService {
+
+    private static final Logger log = LogManager.getLogger(GeminiEmbeddingService.class);
+    private static final String GEMINI_API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/";
+    private static final String DEFAULT_MODEL = "text-embedding-004";
+    private static final int TIMEOUT_MS = 10_000;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String apiKey;
+    private final String model;
+    private final int dimension;
+
+    public GeminiEmbeddingService(String apiKey) {
+        this(apiKey, DEFAULT_MODEL);
+    }
+
+    public GeminiEmbeddingService(String apiKey, String model) {
+        this.apiKey = (apiKey == null) ? "" : apiKey.trim();
+        this.model = (model == null || model.trim().isEmpty()) ? DEFAULT_MODEL : model.trim();
+        this.dimension = resolveDimension(this.model);
+    }
+
+    private static int resolveDimension(String model) {
+        switch (model) {
+            case "text-embedding-004": return 768;
+            case "embedding-001":      return 768;
+            default: return -1;
+        }
+    }
+
+    @Override
+    public float[] embed(String text) throws EmbeddingException {
+        if (text == null || text.isEmpty()) {
+            throw new EmbeddingException("text must not be empty");
+        }
+        return embedBatch(Collections.singletonList(text)).get(0);
+    }
+
+    @Override
+    public EmbeddingResult embedBatch(List<String> texts) throws EmbeddingException {
+        if (!isEnabled()) {
+            throw new EmbeddingException("Gemini API key not configured");
+        }
+        if (texts == null || texts.isEmpty()) {
+            throw new EmbeddingException("texts must not be empty");
+        }
+
+        try {
+            ObjectNode body = MAPPER.createObjectNode();
+            ArrayNode requests = MAPPER.createArrayNode();
+            String modelPath = "models/" + this.model;
+            for (String t : texts) {
+                if (t == null || t.isEmpty()) {
+                    throw new EmbeddingException("batch contains null/empty element");
+                }
+                ObjectNode req = MAPPER.createObjectNode();
+                req.put("model", modelPath);
+                ObjectNode content = MAPPER.createObjectNode();
+                ArrayNode parts = MAPPER.createArrayNode();
+                ObjectNode part = MAPPER.createObjectNode();
+                part.put("text", t);
+                parts.add(part);
+                content.set("parts", parts);
+                req.set("content", content);
+                requests.add(req);
+            }
+            body.set("requests", requests);
+
+            String urlStr = GEMINI_API_URL_BASE + this.model + ":batchEmbedContents?key=" + this.apiKey;
+            URL url = new URL(urlStr);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            conn.setRequestProperty("X-goog-api-key", this.apiKey);
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(TIMEOUT_MS);
+            conn.setReadTimeout(TIMEOUT_MS);
+            conn.setUseCaches(false);
+
+            try (DataOutputStream os = new DataOutputStream(conn.getOutputStream())) {
+                os.write(MAPPER.writeValueAsBytes(body));
+                os.flush();
+            }
+
+            int code = conn.getResponseCode();
+            if (code != HttpURLConnection.HTTP_OK) {
+                String errorBody = readStream(conn.getErrorStream());
+                throw new EmbeddingException("Gemini Embeddings HTTP " + code + ": " + errorBody);
+            }
+
+            String response = readStream(conn.getInputStream());
+            JsonNode json = MAPPER.readTree(response);
+            JsonNode arr = json.get("embeddings");
+            if (arr == null || !arr.isArray()) {
+                throw new EmbeddingException("응답에 embeddings 배열이 없습니다: " + response);
+            }
+            float[][] vectors = new float[arr.size()][];
+            for (int i = 0; i < arr.size(); i++) {
+                JsonNode values = arr.get(i).get("values");
+                if (values == null || !values.isArray()) {
+                    throw new EmbeddingException("embeddings[" + i + "].values 누락");
+                }
+                float[] vec = new float[values.size()];
+                for (int j = 0; j < vec.length; j++) {
+                    vec[j] = (float) values.get(j).asDouble();
+                }
+                vectors[i] = vec;
+            }
+
+            // Gemini batchEmbedContents 응답은 토큰 usage 를 제공하지 않음
+            int promptTokens = 0;
+            log.debug("Gemini embedding 완료: batch={}, dim={}", vectors.length, vectors[0].length);
+            return new EmbeddingResult(vectors, this.model, promptTokens);
+        } catch (EmbeddingException ee) {
+            throw ee;
+        } catch (Exception e) {
+            throw new EmbeddingException("Gemini Embeddings 호출 실패: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return apiKey != null && !apiKey.isEmpty();
+    }
+
+    @Override
+    public int getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public String getModel() {
+        return model;
+    }
+
+    private static String readStream(java.io.InputStream in) throws java.io.IOException {
+        if (in == null) return "";
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) sb.append(line);
+            return sb.toString();
+        }
+    }
+}

--- a/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingService.java
+++ b/smart-ux-api/lib/src/main/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingService.java
@@ -1,0 +1,175 @@
+package com.smartuxapi.ai.embedding.impl;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.smartuxapi.ai.embedding.EmbeddingException;
+import com.smartuxapi.ai.embedding.EmbeddingResult;
+import com.smartuxapi.ai.embedding.EmbeddingService;
+
+/**
+ * OpenAI Embeddings API 기반 EmbeddingService 구현체.
+ *
+ * <p>엔드포인트: {@code POST https://api.openai.com/v1/embeddings}.
+ * 기본 모델 {@code text-embedding-3-small} (1536 차원).
+ *
+ * @since 0.9.0
+ */
+public class OpenAiEmbeddingService implements EmbeddingService {
+
+    private static final Logger log = LogManager.getLogger(OpenAiEmbeddingService.class);
+    private static final String OPENAI_EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings";
+    private static final String DEFAULT_MODEL = "text-embedding-3-small";
+    private static final int TIMEOUT_MS = 10_000;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String apiKey;
+    private final String model;
+    private final int dimension;
+
+    public OpenAiEmbeddingService(String apiKey) {
+        this(apiKey, DEFAULT_MODEL);
+    }
+
+    public OpenAiEmbeddingService(String apiKey, String model) {
+        this.apiKey = (apiKey == null) ? "" : apiKey.trim();
+        this.model = (model == null || model.trim().isEmpty()) ? DEFAULT_MODEL : model.trim();
+        this.dimension = resolveDimension(this.model);
+    }
+
+    private static int resolveDimension(String model) {
+        switch (model) {
+            case "text-embedding-3-small": return 1536;
+            case "text-embedding-3-large": return 3072;
+            case "text-embedding-ada-002": return 1536;
+            default: return -1; // unknown model — dimension 은 실제 호출 후 확인 필요
+        }
+    }
+
+    @Override
+    public float[] embed(String text) throws EmbeddingException {
+        if (text == null || text.isEmpty()) {
+            throw new EmbeddingException("text must not be empty");
+        }
+        EmbeddingResult r = embedBatch(Collections.singletonList(text));
+        return r.get(0);
+    }
+
+    @Override
+    public EmbeddingResult embedBatch(List<String> texts) throws EmbeddingException {
+        if (!isEnabled()) {
+            throw new EmbeddingException("OpenAI API key not configured");
+        }
+        if (texts == null || texts.isEmpty()) {
+            throw new EmbeddingException("texts must not be empty");
+        }
+
+        try {
+            ObjectNode body = MAPPER.createObjectNode();
+            body.put("model", this.model);
+            body.put("encoding_format", "float");
+            ArrayNode inputArr = MAPPER.createArrayNode();
+            for (String t : texts) {
+                if (t == null || t.isEmpty()) {
+                    throw new EmbeddingException("batch contains null/empty element");
+                }
+                inputArr.add(t);
+            }
+            body.set("input", inputArr);
+
+            URL url = new URL(OPENAI_EMBEDDINGS_URL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            conn.setRequestProperty("Authorization", "Bearer " + this.apiKey);
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(TIMEOUT_MS);
+            conn.setReadTimeout(TIMEOUT_MS);
+            conn.setUseCaches(false);
+
+            try (DataOutputStream os = new DataOutputStream(conn.getOutputStream())) {
+                os.write(MAPPER.writeValueAsBytes(body));
+                os.flush();
+            }
+
+            int code = conn.getResponseCode();
+            if (code != HttpURLConnection.HTTP_OK) {
+                String errorBody = readStream(conn.getErrorStream());
+                throw new EmbeddingException("OpenAI Embeddings HTTP " + code + ": " + errorBody);
+            }
+
+            String response = readStream(conn.getInputStream());
+            JsonNode json = MAPPER.readTree(response);
+            JsonNode data = json.get("data");
+            if (data == null || !data.isArray()) {
+                throw new EmbeddingException("응답에 data 배열이 없습니다: " + response);
+            }
+            float[][] vectors = new float[data.size()][];
+            for (int i = 0; i < data.size(); i++) {
+                JsonNode embedding = data.get(i).get("embedding");
+                if (embedding == null || !embedding.isArray()) {
+                    throw new EmbeddingException("data[" + i + "].embedding 누락");
+                }
+                float[] vec = new float[embedding.size()];
+                for (int j = 0; j < vec.length; j++) {
+                    vec[j] = (float) embedding.get(j).asDouble();
+                }
+                vectors[i] = vec;
+            }
+
+            int promptTokens = 0;
+            JsonNode usage = json.get("usage");
+            if (usage != null) {
+                JsonNode pt = usage.get("prompt_tokens");
+                if (pt != null) promptTokens = pt.asInt(0);
+            }
+
+            log.debug("OpenAI embedding 완료: batch={}, dim={}, tokens={}",
+                    vectors.length, vectors[0].length, promptTokens);
+            return new EmbeddingResult(vectors, this.model, promptTokens);
+        } catch (EmbeddingException ee) {
+            throw ee;
+        } catch (Exception e) {
+            throw new EmbeddingException("OpenAI Embeddings 호출 실패: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return apiKey != null && !apiKey.isEmpty();
+    }
+
+    @Override
+    public int getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public String getModel() {
+        return model;
+    }
+
+    private static String readStream(java.io.InputStream in) throws java.io.IOException {
+        if (in == null) return "";
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) sb.append(line);
+            return sb.toString();
+        }
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingResultTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingResultTest.java
@@ -1,0 +1,53 @@
+package com.smartuxapi.ai.embedding;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("EmbeddingResult 단위 테스트")
+class EmbeddingResultTest {
+
+    @Test
+    @DisplayName("기본 필드 — size/dimension/model/promptTokens")
+    void testFields() {
+        float[][] vecs = {
+                {0.1f, 0.2f, 0.3f},
+                {0.4f, 0.5f, 0.6f}
+        };
+        EmbeddingResult r = new EmbeddingResult(vecs, "m", 42);
+        assertEquals(2, r.size());
+        assertEquals(3, r.getDimension());
+        assertEquals("m", r.getModel());
+        assertEquals(42, r.getPromptTokens());
+        assertArrayEquals(new float[]{0.4f, 0.5f, 0.6f}, r.get(1));
+    }
+
+    @Test
+    @DisplayName("model null → 빈 문자열, promptTokens 음수 → 0")
+    void testDefaults() {
+        float[][] vecs = {{1f}};
+        EmbeddingResult r = new EmbeddingResult(vecs, null, -5);
+        assertEquals("", r.getModel());
+        assertEquals(0, r.getPromptTokens());
+    }
+
+    @Test
+    @DisplayName("vectors null/empty → IllegalArgumentException")
+    void testInvalid() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingResult(null, "m", 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingResult(new float[0][], "m", 0));
+    }
+
+    @Test
+    @DisplayName("toString — size/dim/model 포함")
+    void testToString() {
+        float[][] vecs = {{1f, 2f}};
+        String s = new EmbeddingResult(vecs, "mdl", 10).toString();
+        assertTrue(s.contains("size=1"));
+        assertTrue(s.contains("dim=2"));
+        assertTrue(s.contains("mdl"));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingServiceFactoryTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingServiceFactoryTest.java
@@ -1,0 +1,70 @@
+package com.smartuxapi.ai.embedding;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.smartuxapi.ai.embedding.impl.GeminiEmbeddingService;
+import com.smartuxapi.ai.embedding.impl.OpenAiEmbeddingService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("EmbeddingServiceFactory 단위 테스트")
+class EmbeddingServiceFactoryTest {
+
+    @Test
+    @DisplayName("createOpenAI — 기본 모델/차원")
+    void testOpenAI() {
+        EmbeddingService s = EmbeddingServiceFactory.createOpenAI("fake");
+        assertTrue(s instanceof OpenAiEmbeddingService);
+        assertEquals(1536, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("createOpenAI(apiKey, model) — 모델 지정")
+    void testOpenAIWithModel() {
+        EmbeddingService s = EmbeddingServiceFactory.createOpenAI("fake", "text-embedding-3-large");
+        assertEquals(3072, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("createGemini — 기본 모델/차원")
+    void testGemini() {
+        EmbeddingService s = EmbeddingServiceFactory.createGemini("fake");
+        assertTrue(s instanceof GeminiEmbeddingService);
+        assertEquals(768, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("createGemini(apiKey, model) — 모델 지정")
+    void testGeminiWithModel() {
+        EmbeddingService s = EmbeddingServiceFactory.createGemini("fake", "embedding-001");
+        assertEquals(768, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("createOpenAIFromEnv — 환경변수 없으면 disabled")
+    void testOpenAIFromEnvWithoutKey() {
+        // 테스트 환경에 OPENAI_API_KEY 가 없으면 isEnabled=false
+        EmbeddingService s = EmbeddingServiceFactory.createOpenAIFromEnv();
+        String envKey = System.getenv("OPENAI_API_KEY");
+        String propKey = System.getProperty("openai.api.key");
+        if ((envKey == null || envKey.isEmpty()) && (propKey == null || propKey.isEmpty())) {
+            assertFalse(s.isEnabled());
+        } else {
+            assertTrue(s.isEnabled());
+        }
+    }
+
+    @Test
+    @DisplayName("createGeminiFromEnv — 환경변수 없으면 disabled")
+    void testGeminiFromEnvWithoutKey() {
+        EmbeddingService s = EmbeddingServiceFactory.createGeminiFromEnv();
+        String envKey = System.getenv("GEMINI_API_KEY");
+        String propKey = System.getProperty("gemini.api.key");
+        if ((envKey == null || envKey.isEmpty()) && (propKey == null || propKey.isEmpty())) {
+            assertFalse(s.isEnabled());
+        } else {
+            assertTrue(s.isEnabled());
+        }
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingsTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/EmbeddingsTest.java
@@ -1,0 +1,109 @@
+package com.smartuxapi.ai.embedding;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Embeddings 유틸 단위 테스트")
+class EmbeddingsTest {
+
+    private static final float EPS = 1e-5f;
+
+    @Test
+    @DisplayName("cosineSimilarity — 동일 벡터는 1.0, 반대 벡터는 -1.0")
+    void testCosine() {
+        float[] a = {1f, 0f, 0f};
+        float[] b = {1f, 0f, 0f};
+        float[] c = {-1f, 0f, 0f};
+        float[] d = {0f, 1f, 0f};
+        assertEquals(1.0f, Embeddings.cosineSimilarity(a, b), EPS);
+        assertEquals(-1.0f, Embeddings.cosineSimilarity(a, c), EPS);
+        assertEquals(0.0f, Embeddings.cosineSimilarity(a, d), EPS);
+    }
+
+    @Test
+    @DisplayName("cosineSimilarity — 0-벡터는 0.0 반환 (NaN 방지)")
+    void testZeroVector() {
+        float[] zero = {0f, 0f};
+        float[] v = {1f, 2f};
+        assertEquals(0.0f, Embeddings.cosineSimilarity(zero, v));
+        assertEquals(0.0f, Embeddings.cosineSimilarity(v, zero));
+    }
+
+    @Test
+    @DisplayName("cosineSimilarity — 차원 불일치는 IllegalArgumentException")
+    void testDimMismatch() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.cosineSimilarity(new float[]{1f}, new float[]{1f, 2f}));
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.cosineSimilarity(null, new float[]{1f}));
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.cosineSimilarity(new float[0], new float[0]));
+    }
+
+    @Test
+    @DisplayName("argmax — 가장 유사한 후보 인덱스 반환")
+    void testArgmax() {
+        float[][] candidates = {
+                {1f, 0f},      // 가장 비슷
+                {0f, 1f},
+                {-1f, 0f},
+        };
+        EmbeddingResult er = new EmbeddingResult(candidates, "m", 0);
+        float[] query = {0.9f, 0.1f};
+        assertEquals(0, Embeddings.argmax(query, er));
+    }
+
+    @Test
+    @DisplayName("topK — 내림차순 정렬, k>size 면 size 반환")
+    void testTopK() {
+        float[][] candidates = {
+                {1f, 0f},
+                {0.9f, 0.1f},
+                {0f, 1f},
+                {-1f, 0f}
+        };
+        EmbeddingResult er = new EmbeddingResult(candidates, "m", 0);
+        float[] query = {1f, 0f};
+
+        int[] top2 = Embeddings.topK(query, er, 2);
+        assertEquals(2, top2.length);
+        assertEquals(0, top2[0]);  // best
+        assertEquals(1, top2[1]);  // second best
+
+        int[] top10 = Embeddings.topK(query, er, 10);
+        assertEquals(4, top10.length);
+        assertEquals(0, top10[0]);
+        assertEquals(3, top10[3], "가장 먼 후보가 마지막");
+    }
+
+    @Test
+    @DisplayName("argmax/topK — 빈 후보는 IllegalArgumentException, k<=0 도 에러")
+    void testInvalidArgs() {
+        float[] query = {1f};
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.argmax(query, null));
+        EmbeddingResult er = new EmbeddingResult(new float[][]{{1f}}, "m", 0);
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.topK(query, er, 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> Embeddings.topK(query, er, -1));
+    }
+
+    @Test
+    @DisplayName("normalize — L2 norm = 1, 0-벡터는 그대로")
+    void testNormalize() {
+        float[] v = {3f, 4f};
+        float[] n = Embeddings.normalize(v);
+        // |v| = 5 → normalized = [0.6, 0.8]
+        assertEquals(0.6f, n[0], EPS);
+        assertEquals(0.8f, n[1], EPS);
+        // 원본은 그대로
+        assertEquals(3f, v[0]);
+
+        float[] zero = {0f, 0f};
+        float[] nz = Embeddings.normalize(zero);
+        assertArrayEquals(new float[]{0f, 0f}, nz);
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingServiceTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingServiceTest.java
@@ -1,0 +1,54 @@
+package com.smartuxapi.ai.embedding.impl;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.smartuxapi.ai.embedding.EmbeddingException;
+import com.smartuxapi.ai.embedding.EmbeddingService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("GeminiEmbeddingService 단위 테스트")
+class GeminiEmbeddingServiceTest {
+
+    @Test
+    @DisplayName("API 키 없으면 isEnabled()=false")
+    void testDisabled() {
+        assertFalse(new GeminiEmbeddingService(null).isEnabled());
+        assertFalse(new GeminiEmbeddingService("").isEnabled());
+    }
+
+    @Test
+    @DisplayName("기본 모델은 text-embedding-004 (768 차원)")
+    void testDefaultModel() {
+        EmbeddingService s = new GeminiEmbeddingService("fake");
+        assertEquals("text-embedding-004", s.getModel());
+        assertEquals(768, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("embedding-001 → 768 차원")
+    void testAltModel() {
+        EmbeddingService s = new GeminiEmbeddingService("fake", "embedding-001");
+        assertEquals(768, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("미등록 모델 → getDimension()=-1")
+    void testUnknownModel() {
+        assertEquals(-1, new GeminiEmbeddingService("fake", "future-model").getDimension());
+    }
+
+    @Test
+    @DisplayName("비활성 / 빈 입력 / 빈 배치 → EmbeddingException")
+    void testInvalidInputs() {
+        assertThrows(EmbeddingException.class, () -> new GeminiEmbeddingService("").embed("hi"));
+        EmbeddingService s = new GeminiEmbeddingService("fake");
+        assertThrows(EmbeddingException.class, () -> s.embed(""));
+        assertThrows(EmbeddingException.class, () -> s.embed(null));
+        assertThrows(EmbeddingException.class, () -> s.embedBatch(null));
+        assertThrows(EmbeddingException.class, () -> s.embedBatch(Collections.emptyList()));
+    }
+}

--- a/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingServiceTest.java
+++ b/smart-ux-api/lib/src/test/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingServiceTest.java
@@ -1,0 +1,80 @@
+package com.smartuxapi.ai.embedding.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.smartuxapi.ai.embedding.EmbeddingException;
+import com.smartuxapi.ai.embedding.EmbeddingService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("OpenAiEmbeddingService 단위 테스트")
+class OpenAiEmbeddingServiceTest {
+
+    @Test
+    @DisplayName("API 키 없으면 isEnabled()=false")
+    void testDisabled() {
+        assertFalse(new OpenAiEmbeddingService(null).isEnabled());
+        assertFalse(new OpenAiEmbeddingService("").isEnabled());
+        assertFalse(new OpenAiEmbeddingService("   ").isEnabled());
+    }
+
+    @Test
+    @DisplayName("기본 모델은 text-embedding-3-small (1536 차원)")
+    void testDefaultModel() {
+        EmbeddingService s = new OpenAiEmbeddingService("fake");
+        assertEquals("text-embedding-3-small", s.getModel());
+        assertEquals(1536, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("text-embedding-3-large → 3072 차원")
+    void testLargeModel() {
+        EmbeddingService s = new OpenAiEmbeddingService("fake", "text-embedding-3-large");
+        assertEquals(3072, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("미등록 모델 → getDimension()=-1")
+    void testUnknownModel() {
+        EmbeddingService s = new OpenAiEmbeddingService("fake", "custom-model");
+        assertEquals(-1, s.getDimension());
+    }
+
+    @Test
+    @DisplayName("비활성 상태에서 embed 호출 시 EmbeddingException")
+    void testDisabledEmbedThrows() {
+        EmbeddingService s = new OpenAiEmbeddingService("");
+        EmbeddingException ex = assertThrows(EmbeddingException.class, () -> s.embed("hi"));
+        assertTrue(ex.getMessage().contains("API key"));
+    }
+
+    @Test
+    @DisplayName("빈 text / null text → EmbeddingException")
+    void testEmptyText() {
+        EmbeddingService s = new OpenAiEmbeddingService("fake");
+        assertThrows(EmbeddingException.class, () -> s.embed(""));
+        assertThrows(EmbeddingException.class, () -> s.embed(null));
+    }
+
+    @Test
+    @DisplayName("빈/null 배치 → EmbeddingException")
+    void testEmptyBatch() {
+        EmbeddingService s = new OpenAiEmbeddingService("fake");
+        assertThrows(EmbeddingException.class, () -> s.embedBatch(null));
+        assertThrows(EmbeddingException.class, () -> s.embedBatch(Collections.emptyList()));
+    }
+
+    @Test
+    @DisplayName("null 없는 유효한 배치는 사전 검증에서 통과 (네트워크 접근 전)")
+    void testValidBatchPassesInputCheck() {
+        EmbeddingService s = new OpenAiEmbeddingService("");  // disabled
+        // 빈 요소가 섞이면 batch 검증 이전에 isEnabled() 에서 먼저 실패
+        assertThrows(EmbeddingException.class,
+                () -> s.embedBatch(Arrays.asList("ok")),
+                "disabled 상태는 네트워크 호출 전 EmbeddingException");
+    }
+}


### PR DESCRIPTION
## Summary
- **T3-a Embeddings**: Provider 중립 텍스트 임베딩 API (`com.smartuxapi.ai.embedding`)
  - OpenAI `text-embedding-3-small` (1536) / `3-large` (3072)
  - Gemini `text-embedding-004` (768)
  - `Embeddings` 유틸 — cosineSimilarity / argmax / topK / normalize

## Changes
- `lib/build.gradle.kts` version `0.8.1` → `0.9.0`
- `CHANGELOG.md` [0.9.0] 엔트리

## Test plan
- [x] 444 tests / 424 pass / 20 skip / **0 fail** (+60 from 384)
- [x] 로컬 배포 완료 (`smart-ux-api-0.9.0.jar`)
- [ ] 실측 embedding 호출 (OpenAI/Gemini 토큰 소비)

## Notes
- T3-b (Cross-provider Fallback + Cost Telemetry) 는 **v0.9.1 로 이관** — 스케치만 준비 (`doc/tasks/20260422_fallback_telemetry_design_sketch.md`)
- 하위 호환: 기존 ChatRoom/Chatting 경로에 영향 없음, 신규 모듈만 추가
- 차원 mismatch 방지: 한 프로젝트에서 한 provider 만 사용 권장 (문서 §7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)