### PR TITLE
smuxapi-demo v0.9.0 — Embedding 의미 검색 데모

### DIFF
--- a/smuxapi-demo/CHANGELOG.md
+++ b/smuxapi-demo/CHANGELOG.md
@@ -9,6 +9,21 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.9.0] - 2026-04-22
+
+### Added
+- **Embedding 의미 검색 데모 엔드포인트** (`POST /demo/embedding/search`)
+  - smart-ux-api v0.9.0 T3-a 의 `EmbeddingService.embedBatch` + `Embeddings.topK` 사용
+  - 요청: `{provider, query, candidates[], top_k}` (provider: "openai"|"gemini", top_k 기본 3)
+  - 응답: `{query, provider, model, dimension, prompt_tokens, matches: [{index, label, score}]}`
+  - query + candidates 를 **단일 배치 호출** (API 호출 1회) — cosine 은 로컬 계산
+  - 안전장치: candidates 상한 100, 빈 문자열 거부
+
+### Changed
+- smart-ux-api 의존성 `project(":lib")` 가 자동으로 v0.9.0 픽업
+- 버전 `0.8.0` → `0.9.0` (smart-ux-api 와 정렬)
+
+---
 ## [0.8.0] - 2026-04-22
 
 ### Added

--- a/smuxapi-demo/build.gradle.kts
+++ b/smuxapi-demo/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.smartuxapi"
-version = "0.8.0"
+version = "0.9.0"
 
 repositories {
     mavenCentral()

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/controller/EmbeddingController.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/controller/EmbeddingController.java
@@ -1,0 +1,174 @@
+package com.smartuxapi.demo.controller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartuxapi.ai.embedding.EmbeddingResult;
+import com.smartuxapi.ai.embedding.EmbeddingService;
+import com.smartuxapi.ai.embedding.EmbeddingServiceFactory;
+import com.smartuxapi.ai.embedding.Embeddings;
+import com.smartuxapi.util.PropertiesUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Embedding 의미 검색 데모 컨트롤러 (smart-ux-api v0.9.0 T3-a).
+ *
+ * <p>POST /demo/embedding/search
+ * <pre>{
+ *   "provider": "openai" | "gemini",   // 기본 "openai"
+ *   "query": "돌아가고 싶어",
+ *   "candidates": ["취소", "확인", "주문하기", "뒤로가기"],
+ *   "top_k": 3                           // 선택, 기본 3
+ * }</pre>
+ *
+ * <p>반환:
+ * <pre>{
+ *   "query": "...",
+ *   "provider": "openai",
+ *   "model": "text-embedding-3-small",
+ *   "dimension": 1536,
+ *   "prompt_tokens": 42,
+ *   "matches": [
+ *     { "index": 3, "label": "뒤로가기", "score": 0.82 },
+ *     { "index": 0, "label": "취소",   "score": 0.74 },
+ *     { "index": 1, "label": "확인",   "score": 0.31 }
+ *   ]
+ * }</pre>
+ *
+ * <p>실제 API 호출은 query + candidates 의 (N+1) 텍스트에 대한 배치 embedding 1회.
+ * 이후 cosine 계산은 로컬.
+ */
+@RestController
+@RequestMapping("/demo/embedding")
+public class EmbeddingController {
+
+    private static final Logger log = LogManager.getLogger(EmbeddingController.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int DEFAULT_TOP_K = 3;
+    private static final int MAX_CANDIDATES = 100;
+
+    @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<JSONObject> handleSearch(@RequestBody String body, HttpServletRequest req) throws IOException {
+        req.setCharacterEncoding("UTF-8");
+
+        JsonNode root;
+        try {
+            root = MAPPER.readTree(body == null ? "{}" : body);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err("Invalid JSON: " + e.getMessage()));
+        }
+
+        String provider = root.path("provider").asText("openai");
+        String query = root.path("query").asText("");
+        int topK = root.path("top_k").asInt(DEFAULT_TOP_K);
+
+        if (query.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err("query is required"));
+        }
+
+        JsonNode candidatesNode = root.path("candidates");
+        if (!candidatesNode.isArray() || candidatesNode.size() == 0) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err("candidates must be a non-empty array"));
+        }
+        if (candidatesNode.size() > MAX_CANDIDATES) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(err("candidates size exceeds " + MAX_CANDIDATES));
+        }
+
+        List<String> candidates = new ArrayList<>(candidatesNode.size());
+        for (JsonNode n : candidatesNode) {
+            String s = n.asText("");
+            if (s.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(err("candidates contains empty string"));
+            }
+            candidates.add(s);
+        }
+
+        EmbeddingService em = pickService(provider);
+        if (em == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(err("unknown provider or API key missing: " + provider));
+        }
+
+        try {
+            // query + candidates 를 한 번에 배치 임베딩 (API 호출 1회)
+            List<String> batch = new ArrayList<>(candidates.size() + 1);
+            batch.add(query);
+            batch.addAll(candidates);
+
+            EmbeddingResult er = em.embedBatch(batch);
+            float[] queryVec = er.get(0);
+
+            // candidates 용 별도 EmbeddingResult 뷰 생성
+            float[][] candVecs = new float[candidates.size()][];
+            for (int i = 0; i < candidates.size(); i++) {
+                candVecs[i] = er.get(i + 1);
+            }
+            EmbeddingResult candRes = new EmbeddingResult(candVecs, er.getModel(), 0);
+
+            int effectiveK = Math.min(topK, candidates.size());
+            int[] indices = Embeddings.topK(queryVec, candRes, effectiveK);
+
+            JSONArray matches = new JSONArray();
+            for (int idx : indices) {
+                JSONObject m = new JSONObject();
+                m.put("index", idx);
+                m.put("label", candidates.get(idx));
+                m.put("score", (double) Embeddings.cosineSimilarity(queryVec, candRes.get(idx)));
+                matches.add(m);
+            }
+
+            JSONObject res = new JSONObject();
+            res.put("query", query);
+            res.put("provider", provider);
+            res.put("model", er.getModel());
+            res.put("dimension", er.getDimension());
+            res.put("prompt_tokens", er.getPromptTokens());
+            res.put("matches", matches);
+            return ResponseEntity.ok(res);
+        } catch (Exception e) {
+            log.error("embedding search 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(err(e.getClass().getSimpleName() + ": " + e.getMessage()));
+        }
+    }
+
+    private EmbeddingService pickService(String provider) {
+        if ("openai".equalsIgnoreCase(provider)) {
+            String key = PropertiesUtil.get("OPENAI_API_KEY");
+            if (key == null || key.isBlank()) return null;
+            return EmbeddingServiceFactory.createOpenAI(key);
+        }
+        if ("gemini".equalsIgnoreCase(provider)) {
+            String key = PropertiesUtil.get("GEMINI_API_KEY");
+            if (key == null || key.isBlank()) return null;
+            return EmbeddingServiceFactory.createGemini(key);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private JSONObject err(String msg) {
+        JSONObject o = new JSONObject();
+        o.put("status", "error");
+        o.put("message", msg);
+        return o;
+    }
+}


### PR DESCRIPTION
## Summary
smart-ux-api v0.9.0 의 Embedding API 를 실환경에서 시연.

- **`POST /demo/embedding/search`** — UI 의미 검색 (provider "openai"|"gemini")
  - query + candidates 를 단일 배치 호출 → 로컬 cosine → top-k 반환
  - 반환: `{query, provider, model, dimension, prompt_tokens, matches: [{index, label, score}]}`
- **버전 bump**: `0.8.0` → `0.9.0` (smart-ux-api 정렬)

## Test plan
- [x] bootJar 빌드 성공
- [x] 스모크 테스트 7건 통과
  - 6 × 400 경로: 빈 body, candidates 없음, 빈 배열, 빈 문자열, unknown provider, 잘못된 JSON
  - 1 × 200 경로: 실제 OpenAI 호출 (1536 dim, 24 tokens)
- [ ] Gemini 경로 실측 (본 PR 에서는 OpenAI 만 확인)
- [ ] 한국어 짧은 UI 라벨의 의미 해상도 — `text-embedding-3-small` 에서 기대만큼 구분되지 않음 (실사용 관찰, `3-large` / Gemini 로 비교 가치 있음)

## Notes
- candidates 상한 100 / 빈 문자열 거부 등 안전장치 포함
- 기존 `/action` `/collect` `/demo/structured` `/demo/tools` 경로 회귀 없음 (데모만 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)