### PR TITLE
chore(demo): 루트 start.bat 추가 — 원클릭 시연 진입점

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,48 @@
+@echo off
+REM ============================================================
+REM  smart-ux-api — smuxapi-demo Quick Start
+REM ------------------------------------------------------------
+REM  Usage: double-click this file, or run from cmd.
+REM  Requires: Java 17+ installed on PATH
+REM  Effect: Gradle build + Spring Boot bootRun (port 9090)
+REM ============================================================
+setlocal enabledelayedexpansion
+chcp 65001 >nul 2>&1
+
+cd /d "%~dp0"
+
+set "GRADLEW=smart-ux-api\gradlew.bat"
+if not exist "%GRADLEW%" (
+    echo [ERROR] gradlew.bat not found: %GRADLEW%
+    echo Run this from the smart-ux-api repository root.
+    pause
+    exit /b 1
+)
+
+where java >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo [WARN] java command not found on PATH.
+    echo        Gradle toolchain may fetch JDK automatically, but local install is recommended.
+    echo        Install Java 17+ from https://adoptium.net/ if startup fails.
+    echo.
+)
+
+echo ========================================
+echo   Smart UX API - Demo Quick Start
+echo ========================================
+echo   Project root: %cd%
+echo   Port:         9090 (configurable in smuxapi-demo.yml)
+echo   URL:          http://localhost:9090/smuxapi/
+echo ========================================
+echo.
+echo Press Ctrl+C to stop the server.
+echo.
+
+call "%GRADLEW%" -p smuxapi-demo bootRun
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo [ERROR] Failed to start. Check Java 17+ and Gradle setup.
+    pause
+    exit /b %ERRORLEVEL%
+)


### PR DESCRIPTION
## Summary
- 저장소 루트에 `start.bat` 추가
- 더블클릭 또는 `cmd /c .\start.bat` 으로 smuxapi-demo 즉시 기동 (port 9090)
- 내부적으로 `smart-ux-api\gradlew.bat -p smuxapi-demo bootRun` 호출

## Scope (A 안)
muse-agent 패턴의 **간소 버전**만 채택. 추후 확장은 별도 PR:
- [x] 루트 start.bat (1-click)
- [ ] ~~batch/ 폴더 (run/dep 분리)~~ — 후속
- [ ] ~~포트 충돌 감지/재지정~~ — 후속
- [ ] ~~download-jre.ps1 자동 다운로드~~ — 후속
- [ ] ~~muse-agent 급 packaging/distribution 개선~~ — 후속

## Test plan
- [x] 로컬 실행: `cmd /c .\start.bat` → Tomcat 기동 (4초)
- [x] HTTP 응답: `curl http://localhost:9090/smuxapi/` → 200
- [ ] Windows 탐색기 더블클릭 체험 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)