### PR TITLE
chore(demo): start.bat 을 smuxapi-demo/bat/ 로 이동

### DIFF
--- a/smuxapi-demo/bat/start.bat
+++ b/smuxapi-demo/bat/start.bat
@@ -2,19 +2,30 @@
 REM ============================================================
 REM  smart-ux-api — smuxapi-demo Quick Start
 REM ------------------------------------------------------------
-REM  Usage: double-click this file, or run from cmd.
+REM  Location: smuxapi-demo/bat/start.bat
+REM  Usage   : double-click this file, or run from cmd.
 REM  Requires: Java 17+ installed on PATH
-REM  Effect: Gradle build + Spring Boot bootRun (port 9090)
+REM  Effect  : Gradle build + Spring Boot bootRun (port 9090)
 REM ============================================================
 setlocal enabledelayedexpansion
 chcp 65001 >nul 2>&1
 
-cd /d "%~dp0"
+REM Repo root is two levels up from this script (smuxapi-demo/bat → repo root).
+set "SCRIPT_DIR=%~dp0"
+for %%I in ("%SCRIPT_DIR%..\..") do set "REPO_ROOT=%%~fI"
+cd /d "%REPO_ROOT%"
 
 set "GRADLEW=smart-ux-api\gradlew.bat"
 if not exist "%GRADLEW%" (
-    echo [ERROR] gradlew.bat not found: %GRADLEW%
-    echo Run this from the smart-ux-api repository root.
+    echo [ERROR] gradlew.bat not found: %REPO_ROOT%\%GRADLEW%
+    echo Expected repo root: %REPO_ROOT%
+    echo Run this bat from within the smart-ux-api repository.
+    pause
+    exit /b 1
+)
+
+if not exist "smuxapi-demo\build.gradle.kts" (
+    echo [ERROR] smuxapi-demo project not found at: %REPO_ROOT%\smuxapi-demo
     pause
     exit /b 1
 )
@@ -30,7 +41,7 @@ if %ERRORLEVEL% NEQ 0 (
 echo ========================================
 echo   Smart UX API - Demo Quick Start
 echo ========================================
-echo   Project root: %cd%
+echo   Repo root:    %REPO_ROOT%
 echo   Port:         9090 (configurable in smuxapi-demo.yml)
 echo   URL:          http://localhost:9090/smuxapi/
 echo ========================================


### PR DESCRIPTION
## Summary
- 리포지토리 루트의 `start.bat` 제거
- `smuxapi-demo/bat/start.bat` 신설 — 경로 동적 해석 (`%~dp0..\..` → repo root)
- 이후 demo 관련 보조 스크립트 (run/stop/deploy 등) 를 같은 폴더에 모을 수 있도록 구조 정리

## Usage
```
# 더블클릭 OR
cd smart-ux-api
smuxapi-demo\bat\start.bat
```

## Test plan
- [x] PowerShell 로 `smuxapi-demo\bat\start.bat` 실행 → Tomcat started on port 9090
- [x] `curl http://localhost:9090/smuxapi/` → HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)