### PR TITLE
Release v0.9.4 — isFallbackTriggered 정확성 + :lib:deploy 경로 보정

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -9,6 +9,27 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.9.4] - 2026-04-24
+
+### Added
+- **`FallbackContext` ThreadLocal** (`com.smartuxapi.ai.cost.FallbackContext`)
+  - `FallbackChatRoom.runWithFallback` 이 chain 의 2번째 이상 slot 호출 직전 `enterFallback()` 설정, finally 에서 `exit()` 로 해제
+  - `APIConnection` (OpenAI/Gemini) + `VisionService` 구현체 (OpenAI/Gemini) + `EmbeddingService` 구현체 (OpenAI/Gemini) 6곳 의 `recordCost()` 가 `FallbackContext.isFallback()` 을 읽어 `CostEntry.isFallbackTriggered` 필드를 정확히 세팅
+  - v0.9.1 의 알려진 gap 해소 — 이제 fallback 으로 회복된 호출의 `CostEntry` 는 `isFallbackTriggered=true` 로 기록됨
+
+### Fixed
+- **`:lib:deploy` 태스크 경로** — v0.9.2 구조 평탄화 후 `doriboxLibsDir` 이 `../../../doribox/libs` 로 남아있어 잘못된 위치(`DEV/doribox/`) 로 복사되던 문제. `lib/` 기준 `../../doribox/libs` 로 수정
+
+### Tests
+- **신규 7건**:
+  - `FallbackContextTest` (4) — 초기값 / enter-exit / 재진입 / Thread 독립성
+  - `FallbackChatRoomTest` (3) — primary 호출 중 isFallback=false / fallback 호출 중 isFallback=true / 예외 전파 시 finally 로 해제
+- 총 테스트 수: 540 → 554 (+14 이중 집계 포함, 실제 +7건)
+
+### Notes
+- API 시그니처/동작 변경 없음 — 기존 소비자 코드에 영향 없음. telemetry 정확도만 개선.
+
+---
 ## [0.9.3] - 2026-04-22
 
 ### Docs

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.smartuxapi.ai"  // 그룹 ID 설정
-version = "0.9.3"            // 프로젝트 버전 설정
+version = "0.9.4"            // 프로젝트 버전 설정
 
 repositories {
     // Use Maven Central for resolving dependencies.
@@ -214,7 +214,8 @@ tasks.register("deploy") {
     dependsOn("jar")
     
     // 배포 대상 디렉터리 (lib 모듈 기준 상대 경로)
-    val doriboxLibsDir = file("../../../doribox/libs")
+    // v0.9.2 평탄화 후: lib/ → repo root(..)  → github(../..) → ../../doribox
+    val doriboxLibsDir = file("../../doribox/libs")
     
     doFirst {
         println("=".repeat(60))

--- a/lib/src/main/java/com/smartuxapi/ai/cost/FallbackContext.java
+++ b/lib/src/main/java/com/smartuxapi/ai/cost/FallbackContext.java
@@ -1,0 +1,45 @@
+package com.smartuxapi.ai.cost;
+
+/**
+ * Fallback 실행 컨텍스트 — 현재 호출이 fallback 경로인지 {@link ThreadLocal} 로 표시.
+ *
+ * <p>{@code FallbackChatRoom} 이 chain 의 1번째(primary) 를 초과한 slot 호출 직전에
+ * {@link #enterFallback()} 을 호출하고, 호출 종료 후 {@link #exit()} 으로 해제한다.
+ *
+ * <p>{@code APIConnection} / Vision / Embedding 서비스의 {@code recordCost()} 는
+ * {@link #isFallback()} 을 읽어 {@link CostEntry#isFallbackTriggered()} 필드를 세팅한다.
+ *
+ * <p>동기 호출 흐름을 전제로 한다. 비동기/thread pool 처리가 필요하면 ThreadLocal
+ * 전파 전략이 추가로 필요하지만, smart-ux-api 는 현재 모든 API 호출이 호출 스레드에서
+ * 동기 수행되므로 간단하게 구현한다.
+ *
+ * @since 0.9.4
+ */
+public final class FallbackContext {
+
+    private static final ThreadLocal<Boolean> CURRENT = ThreadLocal.withInitial(() -> false);
+
+    private FallbackContext() {}
+
+    /**
+     * 현재 스레드가 fallback 경로를 수행 중이면 true.
+     */
+    public static boolean isFallback() {
+        Boolean v = CURRENT.get();
+        return v != null && v;
+    }
+
+    /**
+     * fallback 경로 진입 표시. 호출 종료 후 반드시 {@link #exit()} 를 호출해야 한다.
+     */
+    public static void enterFallback() {
+        CURRENT.set(Boolean.TRUE);
+    }
+
+    /**
+     * 컨텍스트 해제. ThreadLocal 누수 방지.
+     */
+    public static void exit() {
+        CURRENT.remove();
+    }
+}

--- a/lib/src/main/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingService.java
+++ b/lib/src/main/java/com/smartuxapi/ai/embedding/impl/GeminiEmbeddingService.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.embedding.EmbeddingException;
 import com.smartuxapi.ai.embedding.EmbeddingResult;
 import com.smartuxapi.ai.embedding.EmbeddingService;
@@ -155,7 +156,8 @@ public class GeminiEmbeddingService implements EmbeddingService {
             try {
                 double cost = CostTable.calculate(this.model, 0, 0);  // 0 토큰 → 0 비용
                 CostTracker.INSTANCE.record(new CostEntry(
-                        "gemini", this.model, 0, 0, cost, false, "embedding"));
+                        "gemini", this.model, 0, 0, cost,
+                        FallbackContext.isFallback(), "embedding"));
             } catch (Exception te) {
                 log.warn("CostTracker 기록 실패 (무시): " + te.getMessage());
             }

--- a/lib/src/main/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingService.java
+++ b/lib/src/main/java/com/smartuxapi/ai/embedding/impl/OpenAiEmbeddingService.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.cost.TokenUsageExtractor;
 import com.smartuxapi.ai.embedding.EmbeddingException;
 import com.smartuxapi.ai.embedding.EmbeddingResult;
@@ -147,7 +148,8 @@ public class OpenAiEmbeddingService implements EmbeddingService {
                 TokenUsageExtractor.Usage u = TokenUsageExtractor.fromOpenAi(json);
                 double cost = CostTable.calculate(this.model, u.inputTokens, u.outputTokens);
                 CostTracker.INSTANCE.record(new CostEntry(
-                        "openai", this.model, u.inputTokens, u.outputTokens, cost, false, "embedding"));
+                        "openai", this.model, u.inputTokens, u.outputTokens, cost,
+                        FallbackContext.isFallback(), "embedding"));
             } catch (Exception te) {
                 log.warn("CostTracker 기록 실패 (무시): " + te.getMessage());
             }

--- a/lib/src/main/java/com/smartuxapi/ai/fallback/FallbackChatRoom.java
+++ b/lib/src/main/java/com/smartuxapi/ai/fallback/FallbackChatRoom.java
@@ -15,6 +15,7 @@ import com.smartuxapi.ai.Chatting;
 import com.smartuxapi.ai.cache.CacheHint;
 import com.smartuxapi.ai.cache.CacheMetrics;
 import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.debug.DebugLogger;
 import com.smartuxapi.ai.schema.ResponseSchema;
 import com.smartuxapi.ai.tools.ToolRegistry;
@@ -165,6 +166,8 @@ public final class FallbackChatRoom implements ChatRoom {
         for (int i = 0; i < chain.size(); i++) {
             ProviderSlot slot = chain.get(i);
             boolean isLast = (i == chain.size() - 1);
+            boolean isFallbackAttempt = (i > 0);
+            if (isFallbackAttempt) FallbackContext.enterFallback();
             try {
                 return op.call(slot);
             } catch (Throwable t) {
@@ -188,6 +191,8 @@ public final class FallbackChatRoom implements ChatRoom {
                                 slot.getName(), opName, reason, t.getMessage());
                     }
                 }
+            } finally {
+                if (isFallbackAttempt) FallbackContext.exit();
             }
         }
         FallbackExhaustedException fe = new FallbackExhaustedException(

--- a/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
+++ b/lib/src/main/java/com/smartuxapi/ai/gemini/GeminiAPIConnection.java
@@ -23,6 +23,7 @@ import com.smartuxapi.ai.cache.gemini.GeminiContextCacheStrategy;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.cost.TokenUsageExtractor;
 import com.smartuxapi.ai.schema.ResponseSchema;
 import com.smartuxapi.ai.tools.ToolCall;
@@ -327,7 +328,8 @@ public class GeminiAPIConnection {
             TokenUsageExtractor.Usage u = TokenUsageExtractor.fromGemini(responseJson);
             double cost = CostTable.calculate(this.modelName, u.inputTokens, u.outputTokens);
             CostTracker.INSTANCE.record(new CostEntry(
-                    "gemini", this.modelName, u.inputTokens, u.outputTokens, cost, false, callKind));
+                    "gemini", this.modelName, u.inputTokens, u.outputTokens, cost,
+                    FallbackContext.isFallback(), callKind));
         } catch (Exception e) {
             log.warn("CostTracker 기록 실패 (무시): " + e.getMessage());
         }

--- a/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
+++ b/lib/src/main/java/com/smartuxapi/ai/openai/ResponsesAPIConnection.java
@@ -21,6 +21,7 @@ import com.smartuxapi.ai.cache.CacheStrategy;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.cost.TokenUsageExtractor;
 import com.smartuxapi.ai.schema.ResponseSchema;
 import com.smartuxapi.ai.tools.ToolCall;
@@ -327,7 +328,8 @@ public class ResponsesAPIConnection {
             TokenUsageExtractor.Usage u = TokenUsageExtractor.fromOpenAi(responseJson);
             double cost = CostTable.calculate(this.modelName, u.inputTokens, u.outputTokens);
             CostTracker.INSTANCE.record(new CostEntry(
-                    "openai", this.modelName, u.inputTokens, u.outputTokens, cost, false, callKind));
+                    "openai", this.modelName, u.inputTokens, u.outputTokens, cost,
+                    FallbackContext.isFallback(), callKind));
         } catch (Exception e) {
             log.warn("CostTracker 기록 실패 (무시): " + e.getMessage());
         }

--- a/lib/src/main/java/com/smartuxapi/ai/vision/impl/GeminiVisionService.java
+++ b/lib/src/main/java/com/smartuxapi/ai/vision/impl/GeminiVisionService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.cost.TokenUsageExtractor;
 import com.smartuxapi.ai.vision.ImageScanInfo;
 import com.smartuxapi.ai.vision.VisionException;
@@ -248,7 +249,8 @@ public class GeminiVisionService implements VisionService {
             TokenUsageExtractor.Usage u = TokenUsageExtractor.fromGemini(responseJson);
             double cost = CostTable.calculate(this.model, u.inputTokens, u.outputTokens);
             CostTracker.INSTANCE.record(new CostEntry(
-                    "gemini", this.model, u.inputTokens, u.outputTokens, cost, false, "vision"));
+                    "gemini", this.model, u.inputTokens, u.outputTokens, cost,
+                    FallbackContext.isFallback(), "vision"));
         } catch (Exception e) {
             log.warn("CostTracker 기록 실패 (무시): " + e.getMessage());
         }

--- a/lib/src/main/java/com/smartuxapi/ai/vision/impl/OpenAiVisionService.java
+++ b/lib/src/main/java/com/smartuxapi/ai/vision/impl/OpenAiVisionService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.smartuxapi.ai.cost.CostEntry;
 import com.smartuxapi.ai.cost.CostTable;
 import com.smartuxapi.ai.cost.CostTracker;
+import com.smartuxapi.ai.cost.FallbackContext;
 import com.smartuxapi.ai.cost.TokenUsageExtractor;
 import com.smartuxapi.ai.vision.ImageScanInfo;
 import com.smartuxapi.ai.vision.VisionException;
@@ -159,7 +160,8 @@ public class OpenAiVisionService implements VisionService {
             TokenUsageExtractor.Usage u = TokenUsageExtractor.fromOpenAi(responseJson);
             double cost = CostTable.calculate(this.model, u.inputTokens, u.outputTokens);
             CostTracker.INSTANCE.record(new CostEntry(
-                    "openai", this.model, u.inputTokens, u.outputTokens, cost, false, "vision"));
+                    "openai", this.model, u.inputTokens, u.outputTokens, cost,
+                    FallbackContext.isFallback(), "vision"));
         } catch (Exception e) {
             log.warn("CostTracker 기록 실패 (무시): " + e.getMessage());
         }

--- a/lib/src/test/java/com/smartuxapi/ai/cost/FallbackContextTest.java
+++ b/lib/src/test/java/com/smartuxapi/ai/cost/FallbackContextTest.java
@@ -1,0 +1,58 @@
+package com.smartuxapi.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("FallbackContext 단위 테스트")
+class FallbackContextTest {
+
+    @AfterEach
+    void cleanup() {
+        // 다른 테스트 오염 방지
+        FallbackContext.exit();
+    }
+
+    @Test
+    @DisplayName("초기값은 false")
+    void testDefault() {
+        assertFalse(FallbackContext.isFallback());
+    }
+
+    @Test
+    @DisplayName("enterFallback 후 true, exit 후 다시 false")
+    void testEnterExit() {
+        assertFalse(FallbackContext.isFallback());
+        FallbackContext.enterFallback();
+        assertTrue(FallbackContext.isFallback());
+        FallbackContext.exit();
+        assertFalse(FallbackContext.isFallback());
+    }
+
+    @Test
+    @DisplayName("enterFallback 중복 호출 허용 (idempotent)")
+    void testReentrant() {
+        FallbackContext.enterFallback();
+        FallbackContext.enterFallback();
+        assertTrue(FallbackContext.isFallback());
+        FallbackContext.exit();
+        assertFalse(FallbackContext.isFallback(), "한 번의 exit 로 해제");
+    }
+
+    @Test
+    @DisplayName("Thread 독립성 — 다른 스레드는 영향받지 않음")
+    void testThreadIsolation() throws Exception {
+        FallbackContext.enterFallback();
+        assertTrue(FallbackContext.isFallback());
+
+        final Boolean[] otherThreadValue = new Boolean[1];
+        Thread t = new Thread(() -> otherThreadValue[0] = FallbackContext.isFallback());
+        t.start();
+        t.join();
+
+        assertFalse(otherThreadValue[0], "다른 스레드에서는 false");
+        assertTrue(FallbackContext.isFallback(), "원래 스레드는 여전히 true");
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/ai/fallback/FallbackChatRoomTest.java
+++ b/lib/src/test/java/com/smartuxapi/ai/fallback/FallbackChatRoomTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import com.smartuxapi.ai.ChatRoom;
 import com.smartuxapi.ai.Chatting;
+import com.smartuxapi.ai.cost.FallbackContext;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -171,5 +172,77 @@ class FallbackChatRoomTest {
         assertFalse(ok, "한 쪽 close 실패 → false");
         verify(openai.room, times(1)).close();
         verify(gemini.room, times(1)).close();
+    }
+
+    // ========================================================================
+    // v0.9.4 — FallbackContext ThreadLocal 주입 검증
+    // ========================================================================
+
+    @Test
+    @DisplayName("FallbackContext — primary 호출 중 isFallback()=false")
+    void testContextFalseOnPrimary() throws Exception {
+        Pair openai = setupChatRoom();
+        Pair gemini = setupChatRoom();
+        final Boolean[] captured = new Boolean[1];
+        when(openai.chatting.sendPrompt("hi")).thenAnswer(inv -> {
+            captured[0] = FallbackContext.isFallback();
+            return okResponse("ok");
+        });
+
+        FallbackChatRoom fc = new FallbackChatRoom(
+                FallbackPolicies.openaiPrimaryGeminiFallback(openai.room, gemini.room));
+        fc.getChatting().sendPrompt("hi");
+
+        assertEquals(Boolean.FALSE, captured[0], "primary 호출 중에는 isFallback=false");
+        assertFalse(FallbackContext.isFallback(), "호출 완료 후 ThreadLocal 해제");
+    }
+
+    @Test
+    @DisplayName("FallbackContext — fallback 호출 중 isFallback()=true, 종료 후 false")
+    void testContextTrueOnFallback() throws Exception {
+        Pair openai = setupChatRoom();
+        Pair gemini = setupChatRoom();
+        final Boolean[] primaryCtx = new Boolean[1];
+        final Boolean[] fallbackCtx = new Boolean[1];
+
+        when(openai.chatting.sendPrompt("hi")).thenAnswer(inv -> {
+            primaryCtx[0] = FallbackContext.isFallback();
+            throw new IOException("OpenAI API 호출 실패: 500 - Internal Server Error");
+        });
+        when(gemini.chatting.sendPrompt("hi")).thenAnswer(inv -> {
+            fallbackCtx[0] = FallbackContext.isFallback();
+            return okResponse("from-gemini");
+        });
+
+        FallbackChatRoom fc = new FallbackChatRoom(
+                FallbackPolicies.openaiPrimaryGeminiFallback(openai.room, gemini.room));
+        fc.getChatting().sendPrompt("hi");
+
+        assertEquals(Boolean.FALSE, primaryCtx[0], "primary 호출 시에는 아직 fallback 아님");
+        assertEquals(Boolean.TRUE, fallbackCtx[0], "2번째 slot 호출 중 isFallback=true");
+        assertFalse(FallbackContext.isFallback(), "chain 종료 후 ThreadLocal 해제");
+    }
+
+    @Test
+    @DisplayName("FallbackContext — 예외 전파 후에도 ThreadLocal 해제 (finally 경로)")
+    void testContextClearedOnException() {
+        Pair openai = setupChatRoom();
+        Pair gemini = setupChatRoom();
+        try {
+            when(openai.chatting.sendPrompt("hi"))
+                    .thenThrow(new IOException("500 error"));
+            when(gemini.chatting.sendPrompt("hi"))
+                    .thenThrow(new IOException("503 error"));
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        FallbackChatRoom fc = new FallbackChatRoom(
+                FallbackPolicies.openaiPrimaryGeminiFallback(openai.room, gemini.room));
+        assertThrows(FallbackExhaustedException.class,
+                () -> fc.getChatting().sendPrompt("hi"));
+
+        assertFalse(FallbackContext.isFallback(),
+                "chain 전체 실패 후에도 ThreadLocal 은 깨끗해야 한다");
     }
 }


### PR DESCRIPTION
## Summary
v0.9.1 의 알려진 gap 해소 — fallback 으로 회복된 호출의 `CostEntry.isFallbackTriggered` 가 정확히 `true` 로 기록.

### Added
- `FallbackContext` ThreadLocal (`com.smartuxapi.ai.cost`)
- `FallbackChatRoom.runWithFallback` 이 2번째 이상 slot 호출 시 enter/exit
- 6개 `recordCost` 경로 (APIConnection × 2 + Vision × 2 + Embedding × 2) 에서 읽기

### Fixed
- `:lib:deploy` 의 `doriboxLibsDir` 경로가 v0.9.2 평탄화 후 stale — 수정

## Test plan
- [x] 554 tests / 534 pass / 20 skip / **0 fail** (+14 from 540, 실제 +7)
- [x] FallbackContextTest (4) — 초기값, enter-exit, 재진입, Thread 독립성
- [x] FallbackChatRoomTest 추가 (3) — primary/fallback 중 isFallback 상태, 예외 시 해제
- [x] 로컬 배포 성공: `C:\Users\11A\DEV\github\doribox\libs\smart-ux-api-0.9.4.jar`

## Notes
- API 시그니처/동작 변경 없음 — 기존 소비자 영향 없음, telemetry 정확도만 개선
- 비동기/Thread pool 환경은 향후 별도 전파 전략 필요 (현재 smart-ux-api 는 동기 호출만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)