### PR TITLE
feat(demo v0.10.0): Scenario Collector — Full Scenario Test Case Phase 1

### DIFF
--- a/smuxapi-demo/CHANGELOG.md
+++ b/smuxapi-demo/CHANGELOG.md
@@ -9,6 +9,35 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.10.0] - 2026-04-24
+
+### Added
+- **Scenario Collector — Full Scenario Test Case Phase 1** (`com.smartuxapi.demo.collector`)
+  - `PromptResponseCollector` (`@Component`) — 세션/턴 단위로 UI 정보, 사용자/API 프롬프트, 응답 메시지, action_queue 수집
+  - `ChattingCollector` — `Chatting` Decorator, `sendPrompt` / `sendPromptWithSchema` / `sendPromptWithTools` / `sendPromptExpectingToolCalls` / `continueWithToolResults` 계열 호출 시 turn 캡처
+  - `ActionQueueHandlerCollector` — `ActionQueueHandler` 서브클래스, `getCurViewPrompt` / `getActionQueuePrompt` 호출 시점에 ui_info / api_prompt 캡처 (userMsg 를 `{userMsg}` placeholder 로 치환)
+  - `CollectorChatRoom` — `ChatRoom` Decorator, `getChatting()` 호출 시 `ChattingCollector` 로 래핑
+  - `ScenarioTurn` — 개별 턴 POJO (turnNo, uiInfo, userPrompt, apiPrompt, resMsg, actionQueue)
+- **`smuxapi-demo.yml` 새 키** — `smuxapi.scenario.collect-enabled` (기본 false), `output-path`, `file-prefix`
+- **`ChatRoomService` 통합** — collect-enabled=true 일 때 ChatRoom 자동 wrapping. 비활성 시 기존 코드 경로 완전히 우회 (오버헤드 없음)
+- **JSON 저장 포맷** — `{schemaVersion, sessionId, aiModel, savedAt, turnCount, turns: [{turnNo, uiInfo, userPrompt, apiPrompt, resMsg, actionQueue}]}`. 파일명: `{prefix}-{sessionId}-{yyyyMMdd_HHmmss}.json`
+
+### Changed
+- 버전 `0.9.2` → `0.10.0` (minor bump — 신규 기능 추가)
+- `testImplementation("spring-boot-starter-test")` 에 `spring-boot-starter-logging` exclude 추가 — log4j2 / logback 충돌 해결
+
+### Tests
+- **신규 13건**:
+  - `PromptResponseCollectorTest` (5) — disabled no-op, 기본 플로우+JSON 검증, 빈 상태, reset, sessionId sanitize
+  - `ChattingCollectorTest` (4) — sendPrompt 캡처, disabled passthrough, 예외 전파, getDelegate
+  - `ActionQueueHandlerCollectorTest` (4) — userMsg 치환, no-match, null/empty, null fullPrompt
+
+### Notes
+- **하위 호환**: `collect-enabled=false` (기본) 인 경우 수집 코드는 완전히 우회. 기존 사용자는 영향 없음
+- **Phase 2 (수동 데이터 수집 테스트)**: 사용자가 `collect-enabled: true` 로 변경 후 실제 시나리오 실행 → `./scenarios/` JSON 확인
+- **Phase 3 (smart-ux-api 테스트 러너)**: 후속 릴리스에서 `FullScenarioTestCase`, `ScenarioDataLoader`, `ActionQueueValidator` 등 구현 예정
+
+---
 ## [0.9.2] - 2026-04-22
 
 ### Changed

--- a/smuxapi-demo/build.gradle.kts
+++ b/smuxapi-demo/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.smartuxapi"
-version = "0.9.2"
+version = "0.10.0"
 
 repositories {
     mavenCentral()
@@ -51,7 +51,10 @@ dependencies {
     implementation("org.json:json:20250517")
     
     // 테스트
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        // log4j2 를 본 구현체와 통일하기 위해 logback 을 제외
+        exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+    }
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 }
 

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ActionQueueHandlerCollector.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ActionQueueHandlerCollector.java
@@ -1,0 +1,53 @@
+package com.smartuxapi.demo.collector;
+
+import com.smartuxapi.ai.ActionQueueHandler;
+
+/**
+ * {@link ActionQueueHandler} 서브클래스 — 원본 동작을 그대로 유지하면서
+ * {@link #getCurViewPrompt()} 와 {@link #getActionQueuePrompt(String)} 호출 시점에
+ * {@link PromptResponseCollector} 로 데이터를 전달한다.
+ *
+ * <p>{@code setActionQueueHandler} API 가 {@code ActionQueueHandler} 타입을 요구하므로
+ * Decorator 가 아닌 <b>서브클래스</b> 로 구현.
+ *
+ * @since smuxapi-demo 0.10.0
+ */
+public class ActionQueueHandlerCollector extends ActionQueueHandler {
+
+    private final PromptResponseCollector collector;
+
+    public ActionQueueHandlerCollector(PromptResponseCollector collector) {
+        super();
+        this.collector = collector;
+    }
+
+    @Override
+    public String getCurViewPrompt() {
+        String uiInfo = super.getCurViewPrompt();
+        // uiInfo 가 null 이면 "변경 없음" 의미 — 저장하지 않음 (이전 턴 값이 유지됨)
+        if (uiInfo != null) collector.captureUiInfo(uiInfo);
+        return uiInfo;
+    }
+
+    @Override
+    public String getActionQueuePrompt(String userMsg) {
+        String fullPrompt = super.getActionQueuePrompt(userMsg);
+        if (fullPrompt != null) {
+            String apiPrompt = extractApiPromptTemplate(fullPrompt, userMsg);
+            collector.captureApiPrompt(apiPrompt);
+        }
+        return fullPrompt;
+    }
+
+    /**
+     * userMsg 부분을 플레이스홀더 {@code {userMsg}} 로 치환하여 템플릿 부분을 반환.
+     * userMsg 가 null/empty 거나 fullPrompt 에 포함되지 않으면 원본 그대로 반환.
+     */
+    static String extractApiPromptTemplate(String fullPrompt, String userMsg) {
+        if (fullPrompt == null) return null;
+        if (userMsg == null || userMsg.isEmpty()) return fullPrompt;
+        int idx = fullPrompt.indexOf(userMsg);
+        if (idx < 0) return fullPrompt;
+        return fullPrompt.substring(0, idx) + "{userMsg}" + fullPrompt.substring(idx + userMsg.length());
+    }
+}

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ChattingCollector.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ChattingCollector.java
@@ -1,0 +1,121 @@
+package com.smartuxapi.demo.collector;
+
+import java.util.List;
+import java.util.Set;
+
+import org.json.simple.JSONObject;
+
+import com.smartuxapi.ai.ActionQueueHandler;
+import com.smartuxapi.ai.Chatting;
+import com.smartuxapi.ai.cache.CacheHint;
+import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.schema.ResponseSchema;
+import com.smartuxapi.ai.tools.ToolRegistry;
+import com.smartuxapi.ai.tools.ToolResult;
+
+/**
+ * {@link Chatting} Decorator — sendPrompt* 계열 호출 시 프롬프트/응답을
+ * {@link PromptResponseCollector} 로 전달한다.
+ *
+ * <p>모든 Chatting 인터페이스 메서드를 delegate 에 위임하며, 실제 대화 턴
+ * (sendPrompt / sendPromptWithSchema / sendPromptWithTools) 에서만 수집 로직을 삽입한다.
+ *
+ * @since smuxapi-demo 0.10.0
+ */
+public class ChattingCollector implements Chatting {
+
+    private final Chatting delegate;
+    private final PromptResponseCollector collector;
+
+    public ChattingCollector(Chatting delegate, PromptResponseCollector collector) {
+        this.delegate = delegate;
+        this.collector = collector;
+    }
+
+    @Override
+    public JSONObject sendPrompt(String userMsg) throws Exception {
+        collector.startNewTurn();
+        collector.captureUserPrompt(userMsg);
+        JSONObject response = delegate.sendPrompt(userMsg);
+        captureResponse(response);
+        return response;
+    }
+
+    @Override
+    public JSONObject sendPromptWithSchema(String userMsg, ResponseSchema schema) throws Exception {
+        collector.startNewTurn();
+        collector.captureUserPrompt(userMsg);
+        JSONObject response = delegate.sendPromptWithSchema(userMsg, schema);
+        captureResponse(response);
+        return response;
+    }
+
+    @Override
+    public JSONObject sendPromptWithTools(String userMsg, ToolRegistry tools) throws Exception {
+        collector.startNewTurn();
+        collector.captureUserPrompt(userMsg);
+        JSONObject response = delegate.sendPromptWithTools(userMsg, tools);
+        captureResponse(response);
+        return response;
+    }
+
+    @Override
+    public JSONObject sendPromptExpectingToolCalls(String userMsg, ToolRegistry tools) throws Exception {
+        collector.startNewTurn();
+        collector.captureUserPrompt(userMsg);
+        JSONObject response = delegate.sendPromptExpectingToolCalls(userMsg, tools);
+        captureResponse(response);
+        return response;
+    }
+
+    @Override
+    public JSONObject continueWithToolResults(List<ToolResult> results, ToolRegistry tools) throws Exception {
+        // 수동 dispatch 연속 호출 — 별도 턴으로 취급
+        collector.startNewTurn();
+        JSONObject response = delegate.continueWithToolResults(results, tools);
+        captureResponse(response);
+        return response;
+    }
+
+    private void captureResponse(JSONObject response) {
+        if (response == null) {
+            collector.captureResponse(null, null);
+            return;
+        }
+        Object msg = response.get("message");
+        Object aq = response.get("action_queue");
+        collector.captureResponse(msg == null ? null : msg.toString(), aq);
+    }
+
+    // ----- delegate pass-through -----
+
+    @Override
+    public void setActionQueueHandler(ActionQueueHandler aqHandler) {
+        delegate.setActionQueueHandler(aqHandler);
+    }
+
+    @Override
+    public Set<String> getMessageIdSet() {
+        return delegate.getMessageIdSet();
+    }
+
+    @Override
+    public void setCacheStrategy(CacheStrategy strategy) {
+        delegate.setCacheStrategy(strategy);
+    }
+
+    @Override
+    public CacheStrategy getCacheStrategy() {
+        return delegate.getCacheStrategy();
+    }
+
+    @Override
+    public void applyCacheHint(CacheHint hint) throws Exception {
+        delegate.applyCacheHint(hint);
+    }
+
+    /** Delegate 접근자 — 테스트/고급 사용. */
+    public Chatting getDelegate() {
+        return delegate;
+    }
+}

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/CollectorChatRoom.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/CollectorChatRoom.java
@@ -1,0 +1,125 @@
+package com.smartuxapi.demo.collector;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+
+import com.smartuxapi.ai.ActionQueueHandler;
+import com.smartuxapi.ai.ChatRoom;
+import com.smartuxapi.ai.Chatting;
+import com.smartuxapi.ai.cache.CacheHint;
+import com.smartuxapi.ai.cache.CacheMetrics;
+import com.smartuxapi.ai.cache.CacheStrategy;
+import com.smartuxapi.ai.debug.DebugLogger;
+import com.smartuxapi.ai.tools.ToolRegistry;
+
+/**
+ * {@link ChatRoom} Decorator — inner ChatRoom 의 getChatting() 호출 시 {@link ChattingCollector}
+ * 로 감싸 반환한다. 다른 메서드는 모두 delegate 에 위임.
+ *
+ * <p>ActionQueueHandler 는 {@link ActionQueueHandlerCollector} 로 대체되어 wrapping 된다 —
+ * setter 에서 Collector 로 wrapping 후 delegate 에 전달.
+ *
+ * @since smuxapi-demo 0.10.0
+ */
+public class CollectorChatRoom implements ChatRoom {
+
+    private final ChatRoom delegate;
+    private final PromptResponseCollector collector;
+
+    /** Cached wrapped Chatting — getChatting() 결과를 캐시하여 매 호출마다 새로 생성 방지. */
+    private volatile ChattingCollector cachedChatting;
+    /** Cached wrapped AQH — 동일 이유로 캐시. */
+    private volatile ActionQueueHandlerCollector cachedAq;
+
+    public CollectorChatRoom(ChatRoom delegate, PromptResponseCollector collector) {
+        if (delegate == null) throw new IllegalArgumentException("delegate is required");
+        if (collector == null) throw new IllegalArgumentException("collector is required");
+        this.delegate = delegate;
+        this.collector = collector;
+    }
+
+    public ChatRoom getDelegate() { return delegate; }
+
+    @Override
+    public String getId() { return delegate.getId(); }
+
+    @Override
+    public Chatting getChatting() {
+        Chatting inner = delegate.getChatting();
+        if (inner == null) return null;
+        ChattingCollector c = this.cachedChatting;
+        if (c == null || c.getDelegate() != inner) {
+            c = new ChattingCollector(inner, collector);
+            this.cachedChatting = c;
+        }
+        return c;
+    }
+
+    @Override
+    public boolean close() throws IOException, ParseException {
+        return delegate.close();
+    }
+
+    @Override
+    public void setActionQueueHandler(ActionQueueHandler aqHandler) {
+        // 이미 collector 서브클래스이면 그대로, 아니면 기본 instance 를 replace — 단, 이 경로는
+        // 주로 ChatRoomService 에서 처음 set 할 때 사용되고, 그 때 이미 AQH collector 를 만들어서 넘긴다.
+        if (aqHandler instanceof ActionQueueHandlerCollector) {
+            this.cachedAq = (ActionQueueHandlerCollector) aqHandler;
+            delegate.setActionQueueHandler(aqHandler);
+        } else {
+            // 일반 AQH → 새 collector instance 로 대체 (기존 상태는 빈 상태 — caller 가 addCurrentViewInfo 등으로 재설정)
+            ActionQueueHandlerCollector wrapped = new ActionQueueHandlerCollector(collector);
+            this.cachedAq = wrapped;
+            delegate.setActionQueueHandler(wrapped);
+        }
+    }
+
+    @Override
+    public ActionQueueHandler getActionQueueHandler() {
+        return cachedAq != null ? cachedAq : delegate.getActionQueueHandler();
+    }
+
+    // ----- pass-through -----
+
+    @Override
+    public void setDebugLogger(DebugLogger debugLogger) {
+        delegate.setDebugLogger(debugLogger);
+    }
+
+    @Override
+    public DebugLogger getDebugLogger() {
+        return delegate.getDebugLogger();
+    }
+
+    @Override
+    public void setCacheStrategy(CacheStrategy strategy) {
+        delegate.setCacheStrategy(strategy);
+    }
+
+    @Override
+    public CacheStrategy getCacheStrategy() {
+        return delegate.getCacheStrategy();
+    }
+
+    @Override
+    public void markAsCacheable(CacheHint hint) throws Exception {
+        delegate.markAsCacheable(hint);
+    }
+
+    @Override
+    public CacheMetrics getLastCacheMetrics() {
+        return delegate.getLastCacheMetrics();
+    }
+
+    @Override
+    public void setToolRegistry(ToolRegistry registry) {
+        delegate.setToolRegistry(registry);
+    }
+
+    @Override
+    public ToolRegistry getToolRegistry() {
+        return delegate.getToolRegistry();
+    }
+}

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/PromptResponseCollector.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/PromptResponseCollector.java
@@ -1,0 +1,172 @@
+package com.smartuxapi.demo.collector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * 대화 턴별 프롬프트/응답 데이터 수집기 (session-scoped 는 호출자 판단 — 본 Component 는 singleton).
+ *
+ * <p>Decorator 들이 capture* 메서드를 호출하고, Controller 경계에서 {@link #saveToFile()} 로
+ * JSON 파일을 생성한다.
+ *
+ * <p>Thread-safety: 동일 세션에서 Controller → Service → ChatRoom 호출 흐름은 직렬이므로
+ * 일반적으로 안전. 다만 명시적 세션 격리 필요 시 호출자가 별도 인스턴스 생성.
+ *
+ * @since smuxapi-demo 0.10.0
+ */
+@Component
+public class PromptResponseCollector {
+
+    private static final Logger log = LogManager.getLogger(PromptResponseCollector.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Value("${smuxapi.scenario.collect-enabled:false}")
+    private boolean collectEnabled;
+
+    @Value("${smuxapi.scenario.output-path:./scenarios/}")
+    private String outputPath;
+
+    @Value("${smuxapi.scenario.file-prefix:test-scenario}")
+    private String filePrefix;
+
+    private String sessionId;
+    private String aiModel;
+    private final List<ScenarioTurn> turns = Collections.synchronizedList(new ArrayList<>());
+    private ScenarioTurn currentTurn;
+
+    public boolean isEnabled() {
+        return collectEnabled;
+    }
+
+    /** 세션 메타데이터 설정 — ChatRoomService 에서 첫 wrapping 시 1회 호출. */
+    public synchronized void initSession(String sessionId, String aiModel) {
+        this.sessionId = sessionId;
+        this.aiModel = aiModel;
+    }
+
+    public String getSessionId() { return sessionId; }
+    public String getAiModel() { return aiModel; }
+
+    public int turnCount() { return turns.size(); }
+    public List<ScenarioTurn> snapshotTurns() {
+        return Collections.unmodifiableList(new ArrayList<>(turns));
+    }
+
+    /**
+     * 새 턴 시작. ChattingCollector.sendPrompt 시작부에서 호출.
+     */
+    public synchronized void startNewTurn() {
+        if (!collectEnabled) return;
+        currentTurn = new ScenarioTurn(turns.size() + 1);
+    }
+
+    public synchronized void captureUiInfo(String uiInfo) {
+        if (!collectEnabled || currentTurn == null) return;
+        currentTurn.setUiInfo(uiInfo);
+    }
+
+    public synchronized void captureUserPrompt(String userPrompt) {
+        if (!collectEnabled || currentTurn == null) return;
+        currentTurn.setUserPrompt(userPrompt);
+    }
+
+    public synchronized void captureApiPrompt(String apiPrompt) {
+        if (!collectEnabled || currentTurn == null) return;
+        currentTurn.setApiPrompt(apiPrompt);
+    }
+
+    /**
+     * 응답 캡처 + 턴 종료. message, action_queue 필드 추출.
+     *
+     * @param messageField "message" 값
+     * @param actionQueueField "action_queue" 값 (JsonNode 또는 null)
+     */
+    public synchronized void captureResponse(String messageField, Object actionQueueField) {
+        if (!collectEnabled || currentTurn == null) return;
+        currentTurn.setResMsg(messageField);
+        currentTurn.setActionQueue(actionQueueField);
+        turns.add(currentTurn);
+        currentTurn = null;
+    }
+
+    /**
+     * 현재까지 수집된 턴들을 JSON 파일로 저장.
+     *
+     * @return 저장된 파일 경로 (비활성/빈 상태에서는 null)
+     */
+    public synchronized Path saveToFile() throws IOException {
+        if (!collectEnabled || turns.isEmpty()) return null;
+
+        Path dir = Paths.get(outputPath == null || outputPath.isEmpty() ? "./scenarios/" : outputPath);
+        if (!Files.exists(dir)) {
+            Files.createDirectories(dir);
+        }
+
+        String ts = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String safeSession = sessionId == null ? "nosession" : sessionId.replaceAll("[^a-zA-Z0-9._-]", "_");
+        String prefix = filePrefix == null || filePrefix.isEmpty() ? "test-scenario" : filePrefix;
+        String fileName = String.format("%s-%s-%s.json", prefix, safeSession, ts);
+        Path file = dir.resolve(fileName);
+
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("schemaVersion", 1);
+        root.put("sessionId", sessionId);
+        root.put("aiModel", aiModel);
+        root.put("savedAt", ZonedDateTime.now().toString());
+        root.put("turnCount", turns.size());
+
+        ArrayNode arr = MAPPER.createArrayNode();
+        for (ScenarioTurn t : turns) {
+            ObjectNode n = MAPPER.createObjectNode();
+            n.put("turnNo", t.getTurnNo());
+            n.put("uiInfo", t.getUiInfo());
+            n.put("userPrompt", t.getUserPrompt());
+            n.put("apiPrompt", t.getApiPrompt());
+            n.put("resMsg", t.getResMsg());
+            // action_queue 는 String / JsonNode / JSONObject 등 다양한 타입이 올 수 있으므로 toString → readTree
+            if (t.getActionQueue() != null) {
+                try {
+                    n.set("actionQueue", MAPPER.readTree(t.getActionQueue().toString()));
+                } catch (Exception e) {
+                    n.put("actionQueue", t.getActionQueue().toString());
+                }
+            } else {
+                n.putNull("actionQueue");
+            }
+            arr.add(n);
+        }
+        root.set("turns", arr);
+
+        MAPPER.writeValue(file.toFile(), root);
+        log.info("scenario file saved: {} ({} turns)", file.toAbsolutePath(), turns.size());
+        return file;
+    }
+
+    /**
+     * 세션 상태 초기화 — 테스트 및 재시작 용.
+     */
+    public synchronized void reset() {
+        turns.clear();
+        currentTurn = null;
+        sessionId = null;
+        aiModel = null;
+    }
+}

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ScenarioTurn.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/collector/ScenarioTurn.java
@@ -1,0 +1,39 @@
+package com.smartuxapi.demo.collector;
+
+/**
+ * Full Scenario Test Case 의 한 턴 데이터.
+ *
+ * <p>필드는 full-scenario-test-plan.md §2.1 에 정의됨.
+ *
+ * @since smuxapi-demo 0.10.0
+ */
+public class ScenarioTurn {
+
+    private final int turnNo;
+    private String uiInfo;
+    private String userPrompt;
+    private String apiPrompt;
+    private String resMsg;
+    private Object actionQueue;  // JsonNode or JSONObject — provider 응답 그대로
+
+    public ScenarioTurn(int turnNo) {
+        this.turnNo = turnNo;
+    }
+
+    public int getTurnNo() { return turnNo; }
+
+    public String getUiInfo() { return uiInfo; }
+    public void setUiInfo(String uiInfo) { this.uiInfo = uiInfo; }
+
+    public String getUserPrompt() { return userPrompt; }
+    public void setUserPrompt(String userPrompt) { this.userPrompt = userPrompt; }
+
+    public String getApiPrompt() { return apiPrompt; }
+    public void setApiPrompt(String apiPrompt) { this.apiPrompt = apiPrompt; }
+
+    public String getResMsg() { return resMsg; }
+    public void setResMsg(String resMsg) { this.resMsg = resMsg; }
+
+    public Object getActionQueue() { return actionQueue; }
+    public void setActionQueue(Object actionQueue) { this.actionQueue = actionQueue; }
+}

--- a/smuxapi-demo/src/main/java/com/smartuxapi/demo/service/ChatRoomService.java
+++ b/smuxapi-demo/src/main/java/com/smartuxapi/demo/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.smartuxapi.demo.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -13,6 +14,9 @@ import com.smartuxapi.ai.gemini.GeminiChatRoom;
 import com.smartuxapi.ai.openai.ResponsesChatRoom;
 import com.smartuxapi.ai.openai.assistants.Assistants;
 import com.smartuxapi.ai.openai.assistants.AssistantsThread;
+import com.smartuxapi.demo.collector.ActionQueueHandlerCollector;
+import com.smartuxapi.demo.collector.CollectorChatRoom;
+import com.smartuxapi.demo.collector.PromptResponseCollector;
 import com.smartuxapi.util.PropertiesUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +32,10 @@ import jakarta.servlet.http.HttpSession;
 public class ChatRoomService {
 
     private Logger log = LogManager.getLogger(ChatRoomService.class);
+
+    /** Optional — scenario 수집 활성화 시 wrapping 에 사용. */
+    @Autowired(required = false)
+    private PromptResponseCollector scenarioCollector;
     
     /**
      * ChatRoom을 생성하고 세션에 저장 (Query Parameter)
@@ -135,10 +143,18 @@ public class ChatRoomService {
         }
         
         if (chatRoom != null) {
-            chatRoom.setActionQueueHandler(new ActionQueueHandler());
+            // scenario 수집 활성화 시 CollectorChatRoom 으로 wrapping + ActionQueueHandlerCollector 사용
+            if (scenarioCollector != null && scenarioCollector.isEnabled()) {
+                scenarioCollector.initSession(chatRoom.getId(), aiModel);
+                chatRoom = new CollectorChatRoom(chatRoom, scenarioCollector);
+                chatRoom.setActionQueueHandler(new ActionQueueHandlerCollector(scenarioCollector));
+                log.info("[{}] scenario collection 활성화 — CollectorChatRoom wrapping", chatRoom.getId());
+            } else {
+                chatRoom.setActionQueueHandler(new ActionQueueHandler());
+            }
         }
-        
+
         return chatRoom;
     }
-    
+
 }

--- a/smuxapi-demo/src/main/resources/def.smuxapi-demo.yml
+++ b/smuxapi-demo/src/main/resources/def.smuxapi-demo.yml
@@ -9,3 +9,15 @@ OPENAI_API_KEY: your openai api key
 OPENAI_MODEL: gpt-4.1
 GEMINI_MODEL: gemini-2.5-flash
 GEMINI_API_KEY: your gemini api key
+
+#------------------------------------------------------------------------
+# SCENARIO COLLECTION (v0.10.0+)
+#------------------------------------------------------------------------
+# Full Scenario Test Case 작성을 위한 대화 데이터 수집. 기본 비활성.
+# true 로 변경 후 smuxapi-demo 실행하면 매 대화 턴의 user_prompt / api_prompt /
+# ui_info / res_msg / action_queue 가 JSON 으로 저장된다.
+smuxapi:
+  scenario:
+    collect-enabled: false
+    output-path: "./scenarios/"
+    file-prefix: "test-scenario"

--- a/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/ActionQueueHandlerCollectorTest.java
+++ b/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/ActionQueueHandlerCollectorTest.java
@@ -1,0 +1,39 @@
+package com.smartuxapi.demo.collector;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ActionQueueHandlerCollector 단위 테스트")
+class ActionQueueHandlerCollectorTest {
+
+    @Test
+    @DisplayName("extractApiPromptTemplate — userMsg 를 {userMsg} 로 치환")
+    void testExtractTemplate() {
+        String full = "UI Info: {...} / User: 안녕하세요";
+        String template = ActionQueueHandlerCollector.extractApiPromptTemplate(full, "안녕하세요");
+        assertEquals("UI Info: {...} / User: {userMsg}", template);
+    }
+
+    @Test
+    @DisplayName("userMsg 가 없으면 원본 그대로")
+    void testNoMatch() {
+        String full = "UI Info: xxx";
+        assertEquals("UI Info: xxx",
+                ActionQueueHandlerCollector.extractApiPromptTemplate(full, "미등장문자열"));
+    }
+
+    @Test
+    @DisplayName("userMsg null/empty → 원본 반환")
+    void testEmptyUser() {
+        assertEquals("x", ActionQueueHandlerCollector.extractApiPromptTemplate("x", null));
+        assertEquals("x", ActionQueueHandlerCollector.extractApiPromptTemplate("x", ""));
+    }
+
+    @Test
+    @DisplayName("fullPrompt null → null")
+    void testNullFull() {
+        assertNull(ActionQueueHandlerCollector.extractApiPromptTemplate(null, "x"));
+    }
+}

--- a/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/ChattingCollectorTest.java
+++ b/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/ChattingCollectorTest.java
@@ -1,0 +1,99 @@
+package com.smartuxapi.demo.collector;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.smartuxapi.ai.Chatting;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ChattingCollector Decorator 단위 테스트")
+class ChattingCollectorTest {
+
+    private static PromptResponseCollector newCollector(Path dir) {
+        PromptResponseCollector c = new PromptResponseCollector();
+        ReflectionTestUtils.setField(c, "collectEnabled", true);
+        ReflectionTestUtils.setField(c, "outputPath", dir.toString());
+        ReflectionTestUtils.setField(c, "filePrefix", "cc");
+        return c;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JSONObject resp(String msg, Object aq) {
+        JSONObject r = new JSONObject();
+        r.put("message", msg);
+        r.put("action_queue", aq);
+        return r;
+    }
+
+    @Test
+    @DisplayName("sendPrompt — userMsg / message / action_queue 캡처")
+    void testSendPromptCapture(@TempDir Path dir) throws Exception {
+        PromptResponseCollector collector = newCollector(dir);
+        collector.initSession("s1", "openai");
+
+        Chatting delegate = mock(Chatting.class);
+        when(delegate.sendPrompt("hi")).thenReturn(resp("hello", "{\"a\":1}"));
+
+        ChattingCollector cc = new ChattingCollector(delegate, collector);
+        JSONObject out = cc.sendPrompt("hi");
+
+        assertSame("hello", out.get("message"));
+        verify(delegate).sendPrompt("hi");
+
+        List<ScenarioTurn> turns = collector.snapshotTurns();
+        assertEquals(1, turns.size());
+        assertEquals("hi", turns.get(0).getUserPrompt());
+        assertEquals("hello", turns.get(0).getResMsg());
+        assertEquals("{\"a\":1}", turns.get(0).getActionQueue());
+    }
+
+    @Test
+    @DisplayName("collect-enabled=false 상태에서는 호출만 위임, 기록 없음")
+    void testDisabledPassthrough(@TempDir Path dir) throws Exception {
+        PromptResponseCollector collector = newCollector(dir);
+        ReflectionTestUtils.setField(collector, "collectEnabled", false);
+
+        Chatting delegate = mock(Chatting.class);
+        when(delegate.sendPrompt("x")).thenReturn(resp("y", null));
+
+        ChattingCollector cc = new ChattingCollector(delegate, collector);
+        cc.sendPrompt("x");
+
+        assertEquals(0, collector.turnCount());
+        verify(delegate).sendPrompt("x");
+    }
+
+    @Test
+    @DisplayName("delegate 예외는 그대로 전파 (turn 은 미완성 상태로 남음)")
+    void testExceptionPropagation(@TempDir Path dir) throws Exception {
+        PromptResponseCollector collector = newCollector(dir);
+        collector.initSession("s", "x");
+
+        Chatting delegate = mock(Chatting.class);
+        when(delegate.sendPrompt("x")).thenThrow(new RuntimeException("boom"));
+
+        ChattingCollector cc = new ChattingCollector(delegate, collector);
+        assertThrows(RuntimeException.class, () -> cc.sendPrompt("x"));
+        // 예외 발생 시 captureResponse 는 호출되지 않음 → turns 는 0
+        assertEquals(0, collector.turnCount());
+    }
+
+    @Test
+    @DisplayName("getDelegate — 내부 참조 노출")
+    void testGetDelegate(@TempDir Path dir) {
+        PromptResponseCollector collector = newCollector(dir);
+        Chatting delegate = mock(Chatting.class);
+        ChattingCollector cc = new ChattingCollector(delegate, collector);
+        assertSame(delegate, cc.getDelegate());
+    }
+}

--- a/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/PromptResponseCollectorTest.java
+++ b/smuxapi-demo/src/test/java/com/smartuxapi/demo/collector/PromptResponseCollectorTest.java
@@ -1,0 +1,130 @@
+package com.smartuxapi.demo.collector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("PromptResponseCollector 단위 테스트")
+class PromptResponseCollectorTest {
+
+    private PromptResponseCollector newCollector(Path outputDir, boolean enabled) {
+        PromptResponseCollector c = new PromptResponseCollector();
+        ReflectionTestUtils.setField(c, "collectEnabled", enabled);
+        ReflectionTestUtils.setField(c, "outputPath", outputDir.toString());
+        ReflectionTestUtils.setField(c, "filePrefix", "unittest");
+        return c;
+    }
+
+    @Test
+    @DisplayName("collect-enabled=false 이면 capture 가 no-op")
+    void testDisabled(@TempDir Path dir) throws Exception {
+        PromptResponseCollector c = newCollector(dir, false);
+        c.initSession("sess1", "chatgpt");
+        c.startNewTurn();
+        c.captureUiInfo("ui1");
+        c.captureUserPrompt("hi");
+        c.captureResponse("msg", null);
+        assertEquals(0, c.turnCount());
+        assertNull(c.saveToFile(), "disabled 상태는 파일 미생성");
+    }
+
+    @Test
+    @DisplayName("기본 수집 플로우 — 3턴 기록 후 JSON 저장 + 필드 검증")
+    void testBasicFlow(@TempDir Path dir) throws Exception {
+        PromptResponseCollector c = newCollector(dir, true);
+        c.initSession("sessABC", "gemini");
+
+        // Turn 1
+        c.startNewTurn();
+        c.captureUiInfo("ui-info-1");
+        c.captureApiPrompt("api-prompt-{userMsg}");
+        c.captureUserPrompt("안녕");
+        c.captureResponse("안녕하세요", "{\"action_queue\":[]}");
+
+        // Turn 2
+        c.startNewTurn();
+        c.captureUserPrompt("주문해줘");
+        c.captureResponse("주문 확인", null);
+
+        // Turn 3
+        c.startNewTurn();
+        c.captureUserPrompt("취소");
+        c.captureResponse("취소됨", "{\"x\":1}");
+
+        assertEquals(3, c.turnCount());
+        List<ScenarioTurn> snap = c.snapshotTurns();
+        assertEquals("안녕", snap.get(0).getUserPrompt());
+        assertEquals("ui-info-1", snap.get(0).getUiInfo());
+        assertEquals(2, snap.get(1).getTurnNo());
+        assertNull(snap.get(1).getActionQueue());
+
+        Path saved = c.saveToFile();
+        assertNotNull(saved);
+        assertTrue(Files.exists(saved));
+        assertTrue(saved.getFileName().toString().startsWith("unittest-sessABC-"));
+
+        JsonNode root = new ObjectMapper().readTree(saved.toFile());
+        assertEquals("sessABC", root.get("sessionId").asText());
+        assertEquals("gemini", root.get("aiModel").asText());
+        assertEquals(3, root.get("turnCount").asInt());
+        JsonNode turns = root.get("turns");
+        assertEquals(3, turns.size());
+        assertEquals(1, turns.get(0).get("turnNo").asInt());
+        assertEquals("안녕", turns.get(0).get("userPrompt").asText());
+        assertEquals("{userMsg}",
+                turns.get(0).get("apiPrompt").asText().substring("api-prompt-".length()));
+        // action_queue JSON 파싱 확인
+        assertTrue(turns.get(0).get("actionQueue").isObject());
+        assertTrue(turns.get(2).get("actionQueue").isObject());
+        assertEquals(1, turns.get(2).get("actionQueue").get("x").asInt());
+        assertTrue(turns.get(1).get("actionQueue").isNull());
+    }
+
+    @Test
+    @DisplayName("빈 상태 saveToFile → null (파일 미생성)")
+    void testEmpty(@TempDir Path dir) throws IOException {
+        PromptResponseCollector c = newCollector(dir, true);
+        assertNull(c.saveToFile());
+    }
+
+    @Test
+    @DisplayName("reset — 상태 초기화")
+    void testReset(@TempDir Path dir) {
+        PromptResponseCollector c = newCollector(dir, true);
+        c.initSession("s", "m");
+        c.startNewTurn();
+        c.captureUserPrompt("x");
+        c.captureResponse("y", null);
+        assertEquals(1, c.turnCount());
+        c.reset();
+        assertEquals(0, c.turnCount());
+        assertNull(c.getSessionId());
+    }
+
+    @Test
+    @DisplayName("sessionId 특수문자 → 안전 문자로 변환")
+    void testSessionIdSanitize(@TempDir Path dir) throws Exception {
+        PromptResponseCollector c = newCollector(dir, true);
+        c.initSession("/session?with:unsafe", "chatgpt");
+        c.startNewTurn();
+        c.captureUserPrompt("x");
+        c.captureResponse("y", null);
+        Path saved = c.saveToFile();
+        assertNotNull(saved);
+        String fname = saved.getFileName().toString();
+        assertFalse(fname.contains("/"));
+        assertFalse(fname.contains("?"));
+        assertFalse(fname.contains(":"));
+    }
+}


### PR DESCRIPTION
## Summary
`lib/doc/working/full-scenario-test-plan.md` 의 **Phase 1 (smuxapi-demo 데이터 수집)** 을 구현.
Phase 3 (smart-ux-api 테스트 러너) 는 후속 세션에서 진행.

### 수집 대상
- `ui_info` — `ActionQueueHandler.getCurViewPrompt()` 결과
- `user_prompt` — 원본 사용자 발화
- `api_prompt` — `getActionQueuePrompt(userMsg)` 결과 (userMsg 를 `{userMsg}` 치환)
- `res_msg` — `sendPrompt*` 응답의 message 필드
- `action_queue` — 응답의 action_queue 필드 (JsonNode 그대로)

### 저장 포맷
`./scenarios/{prefix}-{sessionId}-{yyyyMMdd_HHmmss}.json`
```json
{
  "schemaVersion": 1, "sessionId": "...", "aiModel": "chatgpt|gemini",
  "savedAt": "...", "turnCount": N,
  "turns": [{"turnNo": 1, "uiInfo": "...", "userPrompt": "...",
             "apiPrompt": "...", "resMsg": "...", "actionQueue": {...}}]
}
```

## Test plan
- [x] 13 tests / 13 pass / 0 fail (demo 모듈)
- [x] `./gradlew :smuxapi-demo:bootJar` → `smuxapi-demo-0.10.0.jar` 성공
- [x] `log4j2 / logback` 의존성 충돌 해결 (spring-boot-starter-logging exclude)
- [ ] `collect-enabled: true` 설정 후 실제 시나리오 실행 → JSON 생성 확인 (사용자 수동)
- [ ] Phase 3 구현 후 end-to-end 재현 테스트

## Notes
- **하위 호환**: `collect-enabled=false` 기본. 수집 코드는 완전히 우회 (오버헤드 없음)
- ChatRoomService 에 `@Autowired(required=false) PromptResponseCollector` 주입. Spring context 에 bean 이 없거나 disabled 인 경우 기존 경로 그대로 동작
- Log4j2 / Logback 충돌은 사전에 잠재적 이슈였음 — 테스트 dependency 에서 `spring-boot-starter-logging` exclude 로 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)