### PR TITLE
Release v0.9.5 — Full Scenario Test Case Phase 3 (smart-ux-api 테스트 러너)

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -9,6 +9,31 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.9.5] - 2026-04-25
+
+### Added
+- **Full Scenario Test Case — Phase 3 (smart-ux-api 테스트 러너)**
+  `lib/src/test/java/com/smartuxapi/scenario/` 패키지 신설:
+  - `ScenarioData` / `ScenarioTurn` — smuxapi-demo 의 v0.10.0+ Collector 가 저장한 JSON 스키마 호환 모델
+  - `ScenarioDataLoader` — 단일 파일 / classpath 리소스 / 디렉터리 로딩 (`*.json` 만)
+  - `ActionQueueValidator` + `ActionDiff` (Kind: VALUE_DIFFERS / EXPECTED_MISSING / ACTUAL_EXTRA) + `ValidationResult` — Jackson tree deep 비교, JSON Pointer 스타일 path
+  - `TurnTestResult` (PASS / FAIL / ERROR_RUNTIME / SKIPPED) + `ScenarioTestResult` 집계 (passed/failed/errored/skipped/totalElapsedMs/isAllPassed)
+  - `ChatRoomFactory` — 시나리오마다 ChatRoom 생성 (호출자가 OpenAI/Gemini/Mock 선택)
+  - `FullScenarioTestCase` harness — `run(ScenarioData)` 로 각 턴 sendPrompt 재현 → action_queue 비교 → ScenarioTestResult 반환
+- **Test fixture**: `lib/src/test/resources/scenarios/sample-2turn.json` — 2턴 시나리오 샘플
+- **신규 테스트 21건**:
+  - `ScenarioDataLoaderTest` (4) — classpath/file/directory 로딩, 미존재 처리
+  - `ActionQueueValidatorTest` (9) — exact match / scalar 차이 / EXPECTED_MISSING / ACTUAL_EXTRA / 배열 길이 / 타입 불일치 / null 처리
+  - `ScenarioTestResultTest` (4) — TurnTestResult.pass/fail/error/skipped + 집계
+  - `FullScenarioTestCaseHarnessTest` (4, Mockito) — all pass / partial fail / runtime error / factory null
+
+### Notes
+- 이 테스트 러너는 `@Test` 가 아닌 일반 클래스 — 실제 LLM 호출이 필요하므로 사용자가 main 함수나 자체 스크립트에서 의도적으로 실행 (비용 발생)
+- 후속 (선택): `ResultWriter` (파일 출력), `ReportGenerator` (markdown/HTML 리포트). 현 시점은 in-memory 결과만 반환
+- 총 테스트 수: 554 → 596 (+42 이중 집계 포함, 실제 +21건)
+- API 동작 변경 없음 — 테스트 코드만 추가 (lib JAR 산출물에는 영향 없음)
+
+---
 ## [0.9.4] - 2026-04-24
 
 ### Added

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.smartuxapi.ai"  // 그룹 ID 설정
-version = "0.9.4"            // 프로젝트 버전 설정
+version = "0.9.5"            // 프로젝트 버전 설정
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/lib/src/test/java/com/smartuxapi/scenario/ActionDiff.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ActionDiff.java
@@ -1,0 +1,44 @@
+package com.smartuxapi.scenario;
+
+/**
+ * 단일 차이 항목 — JSON pointer-style path + 두 값.
+ *
+ * <p>예:
+ * <ul>
+ *   <li>{@code /actions/0/type} : {@code "click"} ↔ {@code "tap"}</li>
+ *   <li>{@code /actions/2} : {@code [missing]} ↔ {@code {...새 액션...}}</li>
+ * </ul>
+ *
+ * @since lib 0.9.5
+ */
+public final class ActionDiff {
+
+    public enum Kind {
+        VALUE_DIFFERS,    // 동일 path 의 값이 다름
+        EXPECTED_MISSING, // expected 에 있는 path 가 actual 에 없음
+        ACTUAL_EXTRA      // actual 에만 있는 path
+    }
+
+    private final String path;
+    private final Kind kind;
+    private final String expected;
+    private final String actual;
+
+    public ActionDiff(String path, Kind kind, String expected, String actual) {
+        this.path = path;
+        this.kind = kind;
+        this.expected = expected;
+        this.actual = actual;
+    }
+
+    public String getPath() { return path; }
+    public Kind getKind() { return kind; }
+    public String getExpected() { return expected; }
+    public String getActual() { return actual; }
+
+    @Override
+    public String toString() {
+        return String.format("[%s] %s : expected=%s, actual=%s",
+                kind, path, expected, actual);
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ActionQueueValidator.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ActionQueueValidator.java
@@ -1,0 +1,113 @@
+package com.smartuxapi.scenario;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * 두 {@link JsonNode} (expected vs actual) 를 deep 비교하여 {@link ValidationResult} 생성.
+ *
+ * <p>JSON Pointer style path 로 차이 위치 표기:
+ * <ul>
+ *   <li>Object: {@code /key/subKey}</li>
+ *   <li>Array : {@code /array/0/...}</li>
+ * </ul>
+ *
+ * <p>비교 규칙:
+ * <ul>
+ *   <li>type mismatch (object vs array, string vs number 등) → VALUE_DIFFERS</li>
+ *   <li>scalar 값이 같지 않음 → VALUE_DIFFERS</li>
+ *   <li>expected 의 key 가 actual 에 없음 → EXPECTED_MISSING</li>
+ *   <li>actual 의 key 가 expected 에 없음 → ACTUAL_EXTRA</li>
+ *   <li>둘 다 null 이거나 missing → 매치</li>
+ * </ul>
+ *
+ * @since lib 0.9.5
+ */
+public final class ActionQueueValidator {
+
+    private ActionQueueValidator() {}
+
+    public static ValidationResult validate(JsonNode expected, JsonNode actual) {
+        List<ActionDiff> diffs = new ArrayList<>();
+        compare("", expected, actual, diffs);
+        return diffs.isEmpty() ? ValidationResult.exactMatch() : ValidationResult.of(diffs);
+    }
+
+    private static void compare(String path, JsonNode exp, JsonNode act, List<ActionDiff> out) {
+        // null 또는 missing 처리
+        boolean expIsNull = (exp == null) || exp.isNull() || exp.isMissingNode();
+        boolean actIsNull = (act == null) || act.isNull() || act.isMissingNode();
+        if (expIsNull && actIsNull) return;
+        if (expIsNull && !actIsNull) {
+            out.add(new ActionDiff(orRoot(path), ActionDiff.Kind.ACTUAL_EXTRA, "null", act.toString()));
+            return;
+        }
+        if (!expIsNull && actIsNull) {
+            out.add(new ActionDiff(orRoot(path), ActionDiff.Kind.EXPECTED_MISSING, exp.toString(), "null"));
+            return;
+        }
+
+        // 타입 불일치
+        if (exp.getNodeType() != act.getNodeType()) {
+            out.add(new ActionDiff(orRoot(path), ActionDiff.Kind.VALUE_DIFFERS,
+                    nodeTypeStr(exp), nodeTypeStr(act)));
+            return;
+        }
+
+        if (exp.isObject()) {
+            TreeSet<String> allKeys = new TreeSet<>();
+            exp.fieldNames().forEachRemaining(allKeys::add);
+            act.fieldNames().forEachRemaining(allKeys::add);
+            for (String key : allKeys) {
+                String childPath = path + "/" + key;
+                JsonNode e = exp.get(key);
+                JsonNode a = act.get(key);
+                if (e == null) {
+                    out.add(new ActionDiff(childPath, ActionDiff.Kind.ACTUAL_EXTRA, "[absent]", a.toString()));
+                } else if (a == null) {
+                    out.add(new ActionDiff(childPath, ActionDiff.Kind.EXPECTED_MISSING, e.toString(), "[absent]"));
+                } else {
+                    compare(childPath, e, a, out);
+                }
+            }
+            return;
+        }
+
+        if (exp.isArray()) {
+            int es = exp.size();
+            int as = act.size();
+            int min = Math.min(es, as);
+            for (int i = 0; i < min; i++) {
+                compare(path + "/" + i, exp.get(i), act.get(i), out);
+            }
+            for (int i = min; i < es; i++) {
+                out.add(new ActionDiff(path + "/" + i, ActionDiff.Kind.EXPECTED_MISSING,
+                        exp.get(i).toString(), "[absent]"));
+            }
+            for (int i = min; i < as; i++) {
+                out.add(new ActionDiff(path + "/" + i, ActionDiff.Kind.ACTUAL_EXTRA,
+                        "[absent]", act.get(i).toString()));
+            }
+            return;
+        }
+
+        // scalar
+        if (!exp.equals(act)) {
+            out.add(new ActionDiff(orRoot(path), ActionDiff.Kind.VALUE_DIFFERS,
+                    exp.toString(), act.toString()));
+        }
+    }
+
+    private static String orRoot(String path) {
+        return path.isEmpty() ? "/" : path;
+    }
+
+    private static String nodeTypeStr(JsonNode n) {
+        if (n == null) return "null";
+        return n.getNodeType().name() + "(" + n.toString() + ")";
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ActionQueueValidatorTest.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ActionQueueValidatorTest.java
@@ -1,0 +1,115 @@
+package com.smartuxapi.scenario;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ActionQueueValidator 단위 테스트")
+class ActionQueueValidatorTest {
+
+    private static final ObjectMapper M = new ObjectMapper();
+
+    private JsonNode parse(String json) throws Exception {
+        return M.readTree(json);
+    }
+
+    @Test
+    @DisplayName("동일 객체 — exactMatch")
+    void testExactMatch() throws Exception {
+        JsonNode a = parse("{\"actions\":[{\"type\":\"click\",\"target\":\"x\"}]}");
+        JsonNode b = parse("{\"actions\":[{\"type\":\"click\",\"target\":\"x\"}]}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertTrue(r.isExactMatch());
+        assertEquals(0, r.diffCount());
+    }
+
+    @Test
+    @DisplayName("scalar 값 차이 → VALUE_DIFFERS")
+    void testValueDiffers() throws Exception {
+        JsonNode a = parse("{\"actions\":[{\"type\":\"click\"}]}");
+        JsonNode b = parse("{\"actions\":[{\"type\":\"tap\"}]}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertFalse(r.isExactMatch());
+        List<ActionDiff> d = r.getDiffs();
+        assertEquals(1, d.size());
+        assertEquals(ActionDiff.Kind.VALUE_DIFFERS, d.get(0).getKind());
+        assertEquals("/actions/0/type", d.get(0).getPath());
+    }
+
+    @Test
+    @DisplayName("expected 에 있는 key 가 actual 에 없음 → EXPECTED_MISSING")
+    void testExpectedMissing() throws Exception {
+        JsonNode a = parse("{\"actions\":[{\"type\":\"click\",\"meta\":{\"x\":1}}]}");
+        JsonNode b = parse("{\"actions\":[{\"type\":\"click\"}]}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertEquals(1, r.diffCount());
+        assertEquals(ActionDiff.Kind.EXPECTED_MISSING, r.getDiffs().get(0).getKind());
+        assertEquals("/actions/0/meta", r.getDiffs().get(0).getPath());
+    }
+
+    @Test
+    @DisplayName("actual 에만 있는 key → ACTUAL_EXTRA")
+    void testActualExtra() throws Exception {
+        JsonNode a = parse("{\"actions\":[{\"type\":\"click\"}]}");
+        JsonNode b = parse("{\"actions\":[{\"type\":\"click\",\"reason\":\"explained\"}]}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertEquals(1, r.diffCount());
+        assertEquals(ActionDiff.Kind.ACTUAL_EXTRA, r.getDiffs().get(0).getKind());
+    }
+
+    @Test
+    @DisplayName("배열 길이 차 — 모자란 쪽은 EXPECTED_MISSING / ACTUAL_EXTRA")
+    void testArrayLengthDiff() throws Exception {
+        JsonNode a = parse("[1,2,3]");
+        JsonNode b = parse("[1,2]");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertEquals(1, r.diffCount());
+        assertEquals(ActionDiff.Kind.EXPECTED_MISSING, r.getDiffs().get(0).getKind());
+        assertEquals("/2", r.getDiffs().get(0).getPath());
+    }
+
+    @Test
+    @DisplayName("타입 불일치 → VALUE_DIFFERS")
+    void testTypeMismatch() throws Exception {
+        JsonNode a = parse("{\"x\": [1,2]}");
+        JsonNode b = parse("{\"x\": \"text\"}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        assertEquals(1, r.diffCount());
+        assertEquals(ActionDiff.Kind.VALUE_DIFFERS, r.getDiffs().get(0).getKind());
+    }
+
+    @Test
+    @DisplayName("expected null + actual 값 → ACTUAL_EXTRA at /")
+    void testExpectedNullActualValue() throws Exception {
+        ValidationResult r = ActionQueueValidator.validate(null, parse("{\"x\":1}"));
+        assertEquals(1, r.diffCount());
+        assertEquals(ActionDiff.Kind.ACTUAL_EXTRA, r.getDiffs().get(0).getKind());
+        assertEquals("/", r.getDiffs().get(0).getPath());
+    }
+
+    @Test
+    @DisplayName("둘 다 null/missing → exactMatch")
+    void testBothNull() {
+        assertTrue(ActionQueueValidator.validate(null, null).isExactMatch());
+    }
+
+    @Test
+    @DisplayName("countByKind 집계")
+    void testCountByKind() throws Exception {
+        JsonNode a = parse("{\"actions\":[{\"type\":\"click\",\"target\":\"x\",\"extra\":1},{\"type\":\"submit\"}]}");
+        JsonNode b = parse("{\"actions\":[{\"type\":\"tap\",\"target\":\"x\"}]}");
+        ValidationResult r = ActionQueueValidator.validate(a, b);
+        // /actions/0/type: VALUE_DIFFERS
+        // /actions/0/extra: EXPECTED_MISSING
+        // /actions/1: EXPECTED_MISSING
+        assertTrue(r.diffCount() >= 2);
+        assertTrue(r.countByKind(ActionDiff.Kind.VALUE_DIFFERS) >= 1);
+        assertTrue(r.countByKind(ActionDiff.Kind.EXPECTED_MISSING) >= 1);
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ChatRoomFactory.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ChatRoomFactory.java
@@ -1,0 +1,20 @@
+package com.smartuxapi.scenario;
+
+import com.smartuxapi.ai.ChatRoom;
+
+/**
+ * 시나리오 재현 시 ChatRoom 을 만들어 반환하는 함수형 인터페이스.
+ *
+ * <p>호출자가 OpenAI / Gemini / Mock 등 어떤 ChatRoom 을 사용할지 결정. 각 시나리오마다 새 ChatRoom 을
+ * 만들어 격리하는 것이 권장 (대화 히스토리 오염 방지).
+ *
+ * @since lib 0.9.5
+ */
+@FunctionalInterface
+public interface ChatRoomFactory {
+    /**
+     * @param scenario 재현할 시나리오 (aiModel 필드를 보고 분기 가능)
+     * @return 새로 생성된 ChatRoom (caller 가 close() 호출 책임)
+     */
+    ChatRoom create(ScenarioData scenario) throws Exception;
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCase.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCase.java
@@ -1,0 +1,154 @@
+package com.smartuxapi.scenario;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartuxapi.ai.ActionQueueHandler;
+import com.smartuxapi.ai.ChatRoom;
+
+/**
+ * 시나리오 JSON 을 재현(replay) 하여 actual action_queue 를 생성하고
+ * expected 와 비교하는 테스트 러너 (harness).
+ *
+ * <p>JUnit {@code @Test} 가 아닌 일반 클래스 — 실제 LLM 호출이 필요하므로 사용자가 의도적으로
+ * 실행한다 (main 함수 또는 자체 테스트 스크립트에서). 호출 비용이 발생.
+ *
+ * <p>사용 예:
+ * <pre>{@code
+ *   FullScenarioTestCase runner = new FullScenarioTestCase(scenario -> {
+ *       String key = System.getenv("OPENAI_API_KEY");
+ *       return new ResponsesChatRoom(key, "gpt-4.1-mini");
+ *   });
+ *   ScenarioData data = ScenarioDataLoader.load(file);
+ *   ScenarioTestResult result = runner.run(data);
+ *   System.out.println(result);
+ * }</pre>
+ *
+ * <p>현재 범위: 각 턴에서 {@code userPrompt} 를 {@code Chatting.sendPrompt} 로 보내고,
+ * 응답의 {@code action_queue} 를 expected 와 비교.
+ *
+ * <p>다루지 않는 기능 (후속):
+ * <ul>
+ *   <li>{@code uiInfo} 를 ActionQueueHandler 에 주입하여 화면 컨텍스트 재현</li>
+ *   <li>{@code resMsg} 텍스트 비교 (현재는 action_queue 만)</li>
+ *   <li>로깅/리포팅 — {@link ScenarioTestResult} 만 반환, 파일 출력은 별도</li>
+ * </ul>
+ *
+ * @since lib 0.9.5
+ */
+public class FullScenarioTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ChatRoomFactory chatRoomFactory;
+    private final boolean injectUiInfo;
+
+    public FullScenarioTestCase(ChatRoomFactory chatRoomFactory) {
+        this(chatRoomFactory, true);
+    }
+
+    /**
+     * @param chatRoomFactory 시나리오마다 호출되어 새 ChatRoom 생성
+     * @param injectUiInfo true 면 각 턴에서 uiInfo 가 있을 때 ActionQueueHandler.setCurrentViewInfo
+     *                     로 주입 시도 (실패해도 계속 진행)
+     */
+    public FullScenarioTestCase(ChatRoomFactory chatRoomFactory, boolean injectUiInfo) {
+        if (chatRoomFactory == null) throw new IllegalArgumentException("chatRoomFactory is required");
+        this.chatRoomFactory = chatRoomFactory;
+        this.injectUiInfo = injectUiInfo;
+    }
+
+    /**
+     * 한 시나리오를 재현하고 결과 반환. ChatRoom 은 시나리오 단위로 새로 생성/종료.
+     */
+    public ScenarioTestResult run(ScenarioData scenario) throws Exception {
+        return run(scenario, null);
+    }
+
+    /**
+     * 소스 파일명을 명시적으로 전달 (디버깅 / 리포팅용).
+     */
+    public ScenarioTestResult run(ScenarioData scenario, String sourceFileName) throws Exception {
+        if (scenario == null) throw new IllegalArgumentException("scenario is required");
+        ChatRoom chatRoom = chatRoomFactory.create(scenario);
+        if (chatRoom == null) {
+            return new ScenarioTestResult(sourceFileName,
+                    scenario.getSessionId(), scenario.getAiModel(),
+                    skipAll(scenario, "chatRoomFactory returned null (API key missing?)"));
+        }
+        try {
+            List<TurnTestResult> turnResults = new ArrayList<>();
+            for (ScenarioTurn turn : scenario.getTurns()) {
+                turnResults.add(replayTurn(chatRoom, turn));
+            }
+            return new ScenarioTestResult(sourceFileName,
+                    scenario.getSessionId(), scenario.getAiModel(), turnResults);
+        } finally {
+            try {
+                chatRoom.close();
+            } catch (Exception e) {
+                // close 실패는 무시 — 결과 영향 없음
+            }
+        }
+    }
+
+    private static List<TurnTestResult> skipAll(ScenarioData scenario, String reason) {
+        List<TurnTestResult> list = new ArrayList<>();
+        for (ScenarioTurn t : scenario.getTurns()) {
+            list.add(TurnTestResult.skipped(t.getTurnNo(), reason));
+        }
+        return list;
+    }
+
+    private TurnTestResult replayTurn(ChatRoom chatRoom, ScenarioTurn turn) {
+        long start = System.currentTimeMillis();
+        try {
+            // uiInfo 주입 (옵션)
+            if (injectUiInfo && turn.getUiInfo() != null && !turn.getUiInfo().isEmpty()) {
+                ActionQueueHandler aq = chatRoom.getActionQueueHandler();
+                if (aq != null) {
+                    try {
+                        aq.setCurrentViewInfo(turn.getUiInfo());
+                    } catch (Exception e) {
+                        // uiInfo 가 JSON 이 아닌 텍스트일 수도 있으므로 실패 무시 — replay 계속
+                    }
+                }
+            }
+
+            String userMsg = turn.getUserPrompt();
+            JSONObject response = chatRoom.getChatting().sendPrompt(userMsg);
+            JsonNode actualAq = extractActionQueue(response);
+            JsonNode expectedAq = turn.getActionQueue();
+
+            ValidationResult vr = ActionQueueValidator.validate(expectedAq, actualAq);
+            long elapsed = System.currentTimeMillis() - start;
+
+            String expStr = expectedAq == null ? "null" : expectedAq.toString();
+            String actStr = actualAq == null ? "null" : actualAq.toString();
+            if (vr.isExactMatch()) {
+                return TurnTestResult.pass(turn.getTurnNo(), expStr, actStr, elapsed);
+            }
+            return TurnTestResult.fail(turn.getTurnNo(), vr, expStr, actStr, elapsed);
+        } catch (Exception e) {
+            long elapsed = System.currentTimeMillis() - start;
+            return TurnTestResult.error(turn.getTurnNo(),
+                    e.getClass().getSimpleName() + ": " + e.getMessage(), elapsed);
+        }
+    }
+
+    private static JsonNode extractActionQueue(JSONObject response) {
+        if (response == null) return null;
+        Object aq = response.get("action_queue");
+        if (aq == null) return null;
+        if (aq instanceof JsonNode) return (JsonNode) aq;
+        try {
+            return MAPPER.readTree(aq.toString());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCaseHarnessTest.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCaseHarnessTest.java
@@ -1,0 +1,111 @@
+package com.smartuxapi.scenario;
+
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartuxapi.ai.ChatRoom;
+import com.smartuxapi.ai.Chatting;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+
+/**
+ * FullScenarioTestCase 의 harness 동작을 Mockito 로 검증 — 실제 LLM 호출 없이.
+ * 각 시나리오 turn 의 expected vs mock-response 비교가 정상 작동하는지 확인.
+ */
+@DisplayName("FullScenarioTestCase harness 단위 테스트 (Mockito)")
+class FullScenarioTestCaseHarnessTest {
+
+    private static final ObjectMapper M = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
+    private static JSONObject reply(String aqJson) throws Exception {
+        JSONObject r = new JSONObject();
+        r.put("message", "...");
+        r.put("action_queue", aqJson == null ? null : M.readTree(aqJson));
+        return r;
+    }
+
+    private static ScenarioData fixture() throws Exception {
+        return ScenarioDataLoader.loadFromClasspath("scenarios/sample-2turn.json");
+    }
+
+    @Test
+    @DisplayName("모든 턴 응답이 expected 와 정확히 일치 → isAllPassed=true")
+    void testAllPass() throws Exception {
+        ScenarioData scenario = fixture();
+        ChatRoom mockRoom = mock(ChatRoom.class);
+        Chatting mockChatting = mock(Chatting.class);
+        when(mockRoom.getChatting()).thenReturn(mockChatting);
+
+        // 두 턴 모두 expected 와 동일하게 응답
+        when(mockChatting.sendPrompt("주문하기 눌러줘"))
+                .thenReturn(reply("{\"actions\":[{\"type\":\"click\",\"target\":\"order\"}]}"));
+        when(mockChatting.sendPrompt("취소"))
+                .thenReturn(reply("{\"actions\":[{\"type\":\"click\",\"target\":\"cancel\"}]}"));
+
+        FullScenarioTestCase runner = new FullScenarioTestCase(s -> mockRoom, false);
+        ScenarioTestResult result = runner.run(scenario, "fixture");
+
+        assertEquals(2, result.total());
+        assertEquals(2, result.passed());
+        assertTrue(result.isAllPassed());
+    }
+
+    @Test
+    @DisplayName("한 턴이 다른 응답 → fail 1, pass 1")
+    void testPartialFail() throws Exception {
+        ScenarioData scenario = fixture();
+        ChatRoom mockRoom = mock(ChatRoom.class);
+        Chatting mockChatting = mock(Chatting.class);
+        when(mockRoom.getChatting()).thenReturn(mockChatting);
+
+        when(mockChatting.sendPrompt("주문하기 눌러줘"))
+                .thenReturn(reply("{\"actions\":[{\"type\":\"tap\",\"target\":\"order\"}]}")); // tap ≠ click
+        when(mockChatting.sendPrompt("취소"))
+                .thenReturn(reply("{\"actions\":[{\"type\":\"click\",\"target\":\"cancel\"}]}"));
+
+        FullScenarioTestCase runner = new FullScenarioTestCase(s -> mockRoom, false);
+        ScenarioTestResult result = runner.run(scenario, "fixture");
+        assertEquals(1, result.passed());
+        assertEquals(1, result.failed());
+        assertFalse(result.isAllPassed());
+
+        TurnTestResult fail = result.getTurnResults().get(0);
+        assertEquals(TurnTestResult.Status.FAIL, fail.getStatus());
+        assertEquals(ActionDiff.Kind.VALUE_DIFFERS,
+                fail.getValidationResult().getDiffs().get(0).getKind());
+    }
+
+    @Test
+    @DisplayName("재현 도중 예외 → ERROR_RUNTIME")
+    void testRuntimeError() throws Exception {
+        ScenarioData scenario = fixture();
+        ChatRoom mockRoom = mock(ChatRoom.class);
+        Chatting mockChatting = mock(Chatting.class);
+        when(mockRoom.getChatting()).thenReturn(mockChatting);
+        when(mockChatting.sendPrompt(anyString())).thenThrow(new RuntimeException("network"));
+
+        FullScenarioTestCase runner = new FullScenarioTestCase(s -> mockRoom, false);
+        ScenarioTestResult result = runner.run(scenario, "fixture");
+        assertEquals(2, result.errored());
+        assertEquals(0, result.passed());
+        assertFalse(result.isAllPassed());
+        assertTrue(result.getTurnResults().get(0).getErrorMessage().contains("network"));
+    }
+
+    @Test
+    @DisplayName("ChatRoomFactory 가 null 반환 → 모든 턴 SKIPPED")
+    void testFactoryReturnsNull() throws Exception {
+        ScenarioData scenario = fixture();
+        FullScenarioTestCase runner = new FullScenarioTestCase(s -> null, false);
+        ScenarioTestResult result = runner.run(scenario, "fixture");
+        assertEquals(2, result.skipped());
+        assertEquals(0, result.passed());
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioData.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioData.java
@@ -1,0 +1,57 @@
+package com.smartuxapi.scenario;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * 시나리오 JSON 파일 전체.
+ *
+ * <p>대응 포맷 (smuxapi-demo Scenario Collector v0.10.0+):
+ * <pre>{
+ *   "schemaVersion": 1,
+ *   "sessionId": "...",
+ *   "aiModel": "chatgpt|gemini",
+ *   "savedAt": "...",
+ *   "turnCount": N,
+ *   "turns": [ {turnNo, uiInfo, userPrompt, apiPrompt, resMsg, actionQueue}, ... ]
+ * }</pre>
+ *
+ * @since lib 0.9.5
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScenarioData {
+
+    private int schemaVersion = 1;
+    private String sessionId;
+    private String aiModel;
+    private String savedAt;
+    private int turnCount;
+    private List<ScenarioTurn> turns = new ArrayList<>();
+
+    public int getSchemaVersion() { return schemaVersion; }
+    public void setSchemaVersion(int schemaVersion) { this.schemaVersion = schemaVersion; }
+
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+
+    public String getAiModel() { return aiModel; }
+    public void setAiModel(String aiModel) { this.aiModel = aiModel; }
+
+    public String getSavedAt() { return savedAt; }
+    public void setSavedAt(String savedAt) { this.savedAt = savedAt; }
+
+    public int getTurnCount() { return turnCount; }
+    public void setTurnCount(int turnCount) { this.turnCount = turnCount; }
+
+    public List<ScenarioTurn> getTurns() {
+        return turns == null ? Collections.emptyList() : turns;
+    }
+    public void setTurns(List<ScenarioTurn> turns) { this.turns = turns; }
+
+    public int turnSize() {
+        return turns == null ? 0 : turns.size();
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioDataLoader.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioDataLoader.java
@@ -1,0 +1,74 @@
+package com.smartuxapi.scenario;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * 시나리오 JSON 파일을 {@link ScenarioData} 로 로드.
+ *
+ * @since lib 0.9.5
+ */
+public final class ScenarioDataLoader {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ScenarioDataLoader() {}
+
+    public static ScenarioData load(File file) throws IOException {
+        if (file == null || !file.exists()) {
+            throw new IOException("scenario file not found: " + (file == null ? "null" : file.getAbsolutePath()));
+        }
+        return MAPPER.readValue(file, ScenarioData.class);
+    }
+
+    public static ScenarioData load(Path path) throws IOException {
+        return load(path.toFile());
+    }
+
+    /**
+     * 클래스패스 리소스에서 로드 — 테스트 fixture 용.
+     *
+     * @param resourcePath 예: {@code "scenarios/sample.json"}
+     */
+    public static ScenarioData loadFromClasspath(String resourcePath) throws IOException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try (InputStream in = cl.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new IOException("classpath resource not found: " + resourcePath);
+            }
+            return MAPPER.readValue(in, ScenarioData.class);
+        }
+    }
+
+    /**
+     * 디렉터리 내 모든 {@code *.json} 파일을 시간 순 (파일명 오름차순) 으로 로드.
+     */
+    public static List<ScenarioData> loadDirectory(Path dir) throws IOException {
+        if (dir == null || !Files.isDirectory(dir)) {
+            throw new IOException("not a directory: " + dir);
+        }
+        List<ScenarioData> result = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(dir)) {
+            stream
+                .filter(p -> p.getFileName().toString().toLowerCase().endsWith(".json"))
+                .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                .forEach(p -> {
+                    try {
+                        result.add(load(p));
+                    } catch (IOException e) {
+                        throw new RuntimeException("failed to load: " + p, e);
+                    }
+                });
+        }
+        return result;
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioDataLoaderTest.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioDataLoaderTest.java
@@ -1,0 +1,72 @@
+package com.smartuxapi.scenario;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ScenarioDataLoader 단위 테스트")
+class ScenarioDataLoaderTest {
+
+    @Test
+    @DisplayName("classpath fixture 로드 — 2턴 시나리오")
+    void testLoadFromClasspath() throws Exception {
+        ScenarioData data = ScenarioDataLoader.loadFromClasspath("scenarios/sample-2turn.json");
+        assertNotNull(data);
+        assertEquals(1, data.getSchemaVersion());
+        assertEquals("fixture-2turn", data.getSessionId());
+        assertEquals("chatgpt", data.getAiModel());
+        assertEquals(2, data.getTurnCount());
+        assertEquals(2, data.turnSize());
+
+        ScenarioTurn t1 = data.getTurns().get(0);
+        assertEquals(1, t1.getTurnNo());
+        assertEquals("주문하기 눌러줘", t1.getUserPrompt());
+        assertNotNull(t1.getActionQueue());
+        assertEquals("click",
+                t1.getActionQueue().get("actions").get(0).get("type").asText());
+
+        ScenarioTurn t2 = data.getTurns().get(1);
+        assertNull(t2.getUiInfo());
+        assertEquals("cancel",
+                t2.getActionQueue().get("actions").get(0).get("target").asText());
+    }
+
+    @Test
+    @DisplayName("loadFromClasspath — 미존재 리소스 IOException")
+    void testMissingResource() {
+        assertThrows(IOException.class,
+                () -> ScenarioDataLoader.loadFromClasspath("nonexistent.json"));
+    }
+
+    @Test
+    @DisplayName("load(File) — 미존재 파일 IOException")
+    void testMissingFile() {
+        assertThrows(IOException.class,
+                () -> ScenarioDataLoader.load((java.io.File) null));
+    }
+
+    @Test
+    @DisplayName("loadDirectory — 다수 파일 정렬 순 로드 + 비-JSON 무시")
+    void testLoadDirectory(@TempDir Path dir) throws Exception {
+        // sample fixture 를 임시 디렉터리에 2번 복사 + non-JSON 파일 추가
+        ScenarioData base = ScenarioDataLoader.loadFromClasspath("scenarios/sample-2turn.json");
+        com.fasterxml.jackson.databind.ObjectMapper m = new com.fasterxml.jackson.databind.ObjectMapper();
+
+        Path a = dir.resolve("a-scenario.json");
+        Path b = dir.resolve("b-scenario.json");
+        Path c = dir.resolve("c-not-json.txt");
+        m.writeValue(a.toFile(), base);
+        m.writeValue(b.toFile(), base);
+        Files.write(c, "ignored".getBytes());
+
+        java.util.List<ScenarioData> loaded = ScenarioDataLoader.loadDirectory(dir);
+        assertEquals(2, loaded.size(), "non-json 파일은 무시");
+        assertEquals(2, loaded.get(0).turnSize());
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioTestResult.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioTestResult.java
@@ -1,0 +1,58 @@
+package com.smartuxapi.scenario;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 시나리오(파일) 단위 테스트 결과 — 다수의 {@link TurnTestResult} 집계.
+ *
+ * @since lib 0.9.5
+ */
+public final class ScenarioTestResult {
+
+    private final String sourceFileName;
+    private final String sessionId;
+    private final String aiModel;
+    private final List<TurnTestResult> turnResults;
+
+    public ScenarioTestResult(String sourceFileName, String sessionId, String aiModel,
+                              List<TurnTestResult> turnResults) {
+        this.sourceFileName = sourceFileName;
+        this.sessionId = sessionId;
+        this.aiModel = aiModel;
+        this.turnResults = turnResults == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(turnResults));
+    }
+
+    public String getSourceFileName() { return sourceFileName; }
+    public String getSessionId() { return sessionId; }
+    public String getAiModel() { return aiModel; }
+    public List<TurnTestResult> getTurnResults() { return turnResults; }
+
+    public int total()   { return turnResults.size(); }
+    public int passed()  { return countByStatus(TurnTestResult.Status.PASS); }
+    public int failed()  { return countByStatus(TurnTestResult.Status.FAIL); }
+    public int errored() { return countByStatus(TurnTestResult.Status.ERROR_RUNTIME); }
+    public int skipped() { return countByStatus(TurnTestResult.Status.SKIPPED); }
+
+    private int countByStatus(TurnTestResult.Status s) {
+        return (int) turnResults.stream().filter(t -> t.getStatus() == s).count();
+    }
+
+    public boolean isAllPassed() {
+        return failed() == 0 && errored() == 0 && passed() > 0;
+    }
+
+    public long totalElapsedMs() {
+        return turnResults.stream().mapToLong(TurnTestResult::getElapsedMs).sum();
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "ScenarioTestResult{file=%s, total=%d, pass=%d, fail=%d, error=%d, skip=%d, %dms}",
+                sourceFileName, total(), passed(), failed(), errored(), skipped(), totalElapsedMs());
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioTestResultTest.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioTestResultTest.java
@@ -1,0 +1,76 @@
+package com.smartuxapi.scenario;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ScenarioTestResult / TurnTestResult 단위 테스트")
+class ScenarioTestResultTest {
+
+    @Test
+    @DisplayName("TurnTestResult.pass 생성 + 상태 확인")
+    void testPass() {
+        TurnTestResult t = TurnTestResult.pass(1, "exp", "act", 250L);
+        assertEquals(TurnTestResult.Status.PASS, t.getStatus());
+        assertTrue(t.isPass());
+        assertEquals(1, t.getTurnNo());
+        assertEquals(250L, t.getElapsedMs());
+        assertNotNull(t.getValidationResult());
+        assertTrue(t.getValidationResult().isExactMatch());
+    }
+
+    @Test
+    @DisplayName("TurnTestResult.fail / error / skipped")
+    void testNonPass() {
+        ValidationResult vr = ValidationResult.of(java.util.Collections.singletonList(
+                new ActionDiff("/x", ActionDiff.Kind.VALUE_DIFFERS, "1", "2")));
+        TurnTestResult fail = TurnTestResult.fail(2, vr, "{}", "{}", 100L);
+        assertEquals(TurnTestResult.Status.FAIL, fail.getStatus());
+        assertEquals(1, fail.getValidationResult().diffCount());
+
+        TurnTestResult err = TurnTestResult.error(3, "boom", 50L);
+        assertEquals(TurnTestResult.Status.ERROR_RUNTIME, err.getStatus());
+        assertEquals("boom", err.getErrorMessage());
+
+        TurnTestResult sk = TurnTestResult.skipped(4, "no api key");
+        assertEquals(TurnTestResult.Status.SKIPPED, sk.getStatus());
+        assertEquals("no api key", sk.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("ScenarioTestResult — 집계 카운터")
+    void testAggregation() {
+        TurnTestResult p1 = TurnTestResult.pass(1, "", "", 100L);
+        TurnTestResult p2 = TurnTestResult.pass(2, "", "", 200L);
+        ValidationResult vr = ValidationResult.of(java.util.Collections.singletonList(
+                new ActionDiff("/x", ActionDiff.Kind.VALUE_DIFFERS, "a", "b")));
+        TurnTestResult f3 = TurnTestResult.fail(3, vr, "", "", 150L);
+        TurnTestResult e4 = TurnTestResult.error(4, "x", 10L);
+        TurnTestResult s5 = TurnTestResult.skipped(5, "skip");
+
+        ScenarioTestResult r = new ScenarioTestResult("file.json", "sess1", "chatgpt",
+                Arrays.asList(p1, p2, f3, e4, s5));
+        assertEquals(5, r.total());
+        assertEquals(2, r.passed());
+        assertEquals(1, r.failed());
+        assertEquals(1, r.errored());
+        assertEquals(1, r.skipped());
+        assertFalse(r.isAllPassed());
+        assertEquals(460L, r.totalElapsedMs());
+    }
+
+    @Test
+    @DisplayName("isAllPassed — 모두 PASS 일 때만 true (skipped 무관)")
+    void testAllPassed() {
+        ScenarioTestResult ok = new ScenarioTestResult("f", "s", "m",
+                Arrays.asList(TurnTestResult.pass(1, "", "", 0L)));
+        assertTrue(ok.isAllPassed());
+
+        ScenarioTestResult empty = new ScenarioTestResult("f", "s", "m",
+                java.util.Collections.emptyList());
+        assertFalse(empty.isAllPassed(), "빈 결과는 통과 아님");
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ScenarioTurn.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ScenarioTurn.java
@@ -1,0 +1,41 @@
+package com.smartuxapi.scenario;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * smuxapi-demo 의 Scenario Collector 가 저장한 JSON 의 단일 턴.
+ *
+ * <p>필드 이름은 {@code com.smartuxapi.demo.collector.ScenarioTurn} 의 직렬화 결과와 호환:
+ * {@code turnNo, uiInfo, userPrompt, apiPrompt, resMsg, actionQueue}.
+ *
+ * @since lib 0.9.5
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScenarioTurn {
+
+    private int turnNo;
+    private String uiInfo;
+    private String userPrompt;
+    private String apiPrompt;
+    private String resMsg;
+    private JsonNode actionQueue;
+
+    public int getTurnNo() { return turnNo; }
+    public void setTurnNo(int turnNo) { this.turnNo = turnNo; }
+
+    public String getUiInfo() { return uiInfo; }
+    public void setUiInfo(String uiInfo) { this.uiInfo = uiInfo; }
+
+    public String getUserPrompt() { return userPrompt; }
+    public void setUserPrompt(String userPrompt) { this.userPrompt = userPrompt; }
+
+    public String getApiPrompt() { return apiPrompt; }
+    public void setApiPrompt(String apiPrompt) { this.apiPrompt = apiPrompt; }
+
+    public String getResMsg() { return resMsg; }
+    public void setResMsg(String resMsg) { this.resMsg = resMsg; }
+
+    public JsonNode getActionQueue() { return actionQueue; }
+    public void setActionQueue(JsonNode actionQueue) { this.actionQueue = actionQueue; }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/TurnTestResult.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/TurnTestResult.java
@@ -1,0 +1,70 @@
+package com.smartuxapi.scenario;
+
+/**
+ * 단일 턴의 테스트 결과 — expected vs actual 비교 결과 + 상태.
+ *
+ * @since lib 0.9.5
+ */
+public final class TurnTestResult {
+
+    public enum Status {
+        PASS,                 // ValidationResult.isExactMatch
+        FAIL,                 // diff 존재
+        ERROR_RUNTIME,        // 재현 도중 예외 (네트워크/API)
+        SKIPPED               // 의도적 skip (예: API 키 부재)
+    }
+
+    private final int turnNo;
+    private final Status status;
+    private final ValidationResult validationResult;  // PASS/FAIL 일 때만 non-null
+    private final String errorMessage;                // ERROR_RUNTIME / SKIPPED 일 때만 non-null
+    private final String expectedActionQueue;         // 디버그용 직렬화 string
+    private final String actualActionQueue;
+    private final long elapsedMs;
+
+    private TurnTestResult(int turnNo, Status status, ValidationResult vr,
+                           String errMsg, String exp, String act, long elapsedMs) {
+        this.turnNo = turnNo;
+        this.status = status;
+        this.validationResult = vr;
+        this.errorMessage = errMsg;
+        this.expectedActionQueue = exp;
+        this.actualActionQueue = act;
+        this.elapsedMs = elapsedMs;
+    }
+
+    public static TurnTestResult pass(int turnNo, String exp, String act, long elapsedMs) {
+        return new TurnTestResult(turnNo, Status.PASS, ValidationResult.exactMatch(),
+                null, exp, act, elapsedMs);
+    }
+
+    public static TurnTestResult fail(int turnNo, ValidationResult vr,
+                                      String exp, String act, long elapsedMs) {
+        return new TurnTestResult(turnNo, Status.FAIL, vr, null, exp, act, elapsedMs);
+    }
+
+    public static TurnTestResult error(int turnNo, String errMsg, long elapsedMs) {
+        return new TurnTestResult(turnNo, Status.ERROR_RUNTIME, null, errMsg, null, null, elapsedMs);
+    }
+
+    public static TurnTestResult skipped(int turnNo, String reason) {
+        return new TurnTestResult(turnNo, Status.SKIPPED, null, reason, null, null, 0L);
+    }
+
+    public int getTurnNo() { return turnNo; }
+    public Status getStatus() { return status; }
+    public ValidationResult getValidationResult() { return validationResult; }
+    public String getErrorMessage() { return errorMessage; }
+    public String getExpectedActionQueue() { return expectedActionQueue; }
+    public String getActualActionQueue() { return actualActionQueue; }
+    public long getElapsedMs() { return elapsedMs; }
+
+    public boolean isPass() { return status == Status.PASS; }
+
+    @Override
+    public String toString() {
+        return String.format("Turn#%d %s%s",
+                turnNo, status,
+                validationResult == null ? "" : " " + validationResult);
+    }
+}

--- a/lib/src/test/java/com/smartuxapi/scenario/ValidationResult.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/ValidationResult.java
@@ -1,0 +1,48 @@
+package com.smartuxapi.scenario;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Action Queue 비교 결과 — 차이 목록 + 매칭 여부.
+ *
+ * @since lib 0.9.5
+ */
+public final class ValidationResult {
+
+    private final List<ActionDiff> diffs;
+
+    private ValidationResult(List<ActionDiff> diffs) {
+        this.diffs = diffs == null ? Collections.emptyList()
+                : Collections.unmodifiableList(diffs);
+    }
+
+    public static ValidationResult exactMatch() {
+        return new ValidationResult(Collections.emptyList());
+    }
+
+    public static ValidationResult of(List<ActionDiff> diffs) {
+        return new ValidationResult(new ArrayList<>(diffs));
+    }
+
+    public List<ActionDiff> getDiffs() { return diffs; }
+
+    public boolean isExactMatch() {
+        return diffs.isEmpty();
+    }
+
+    public int diffCount() {
+        return diffs.size();
+    }
+
+    public int countByKind(ActionDiff.Kind kind) {
+        return (int) diffs.stream().filter(d -> d.getKind() == kind).count();
+    }
+
+    @Override
+    public String toString() {
+        if (isExactMatch()) return "ValidationResult{exactMatch}";
+        return "ValidationResult{diffs=" + diffs.size() + "}";
+    }
+}


### PR DESCRIPTION
## Summary
`lib/doc/working/full-scenario-test-plan.md` 의 **Phase 3 (smart-ux-api 테스트 러너)** 코어 구현.
smuxapi-demo v0.10.0+ Collector 가 저장한 JSON 시나리오를 재현하여 actual `action_queue` 를 expected 와 비교.

## Added (lib/src/test/java/com/smartuxapi/scenario/)
- `ScenarioData` / `ScenarioTurn` — Collector JSON 호환 모델
- `ScenarioDataLoader` — 단일/classpath/디렉터리 로드
- `ActionQueueValidator` + `ActionDiff` + `ValidationResult` — Jackson tree deep 비교
- `TurnTestResult` (PASS/FAIL/ERROR_RUNTIME/SKIPPED) + `ScenarioTestResult`
- `ChatRoomFactory` (함수형) + `FullScenarioTestCase` harness
- Fixture: `lib/src/test/resources/scenarios/sample-2turn.json`

## Test plan
- [x] **596 tests / 576 pass / 20 skip / 0 fail** (+42 from 554, 실제 +21건)
- [x] `:lib:deploy` 성공: `C:\...\doribox\libs\smart-ux-api-0.9.5.jar`
- [ ] 실제 LLM 호출 통합 검증 (사용자 수동 — `FullScenarioTestCase` 의 main 함수나 자체 스크립트)

## Notes
- 이 테스트 러너는 `@Test` 가 아닌 일반 클래스 — 실제 LLM 호출이 필요해 사용자가 의도적으로 실행 (비용)
- API 동작 변경 없음 — 테스트 코드만 추가 (JAR 산출물 영향 없음)
- 후속 (선택): `ResultWriter` (파일 출력), `ReportGenerator` (markdown/HTML 리포트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)