### PR TITLE
test(lib v0.9.6): Real LLM 통합 테스트 + Phase 3 검증

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -9,6 +9,28 @@
   - Patch: 기존 버전과 호환되면서 버그를 수정한 것일 때 증가
   
 ---
+## [0.9.6] - 2026-04-25
+
+### Added
+- **`FullScenarioTestCaseRealLlmIT`** — opt-in 실 LLM 통합 테스트
+  - `@EnabledIfEnvironmentVariable` 패턴 — `OPENAI_API_KEY` + `SCENARIO_FILE` 환경변수 둘 다 설정 시에만 실행
+  - 단일 파일 또는 디렉터리 경로 모두 지원 (디렉터리는 모든 `*.json` 일괄 재현)
+  - `aiModel` 필드 기준 자동 분기: `chatgpt`/`openai` → `ResponsesChatRoom`, `gemini` → `GeminiChatRoom`
+  - `OPENAI_MODEL` / `GEMINI_MODEL` 환경변수로 모델 override 가능 (기본 `gpt-4.1-mini` / `gemini-2.5-flash`)
+  - 턴별 결과 stdout 출력 (PASS/FAIL/ERROR_RUNTIME/SKIPPED + diff 미리보기)
+
+### Verified
+- Phase 2 에서 캡처된 실제 시나리오 JSON (`test-scenario-{sessionId}-{ts}.json`, 2 turn) 재현
+  - 결과: 2 PASS / 0 FAIL / 0 ERROR / 6,051ms / 추정 비용 ~$0.002
+  - Turn #1 (학습 프롬프트): 3,768ms PASS, Turn #2 ("hello"): 2,283ms PASS
+  - 두 턴 모두 `action_queue: null` (캡처 시 UI 컨텍스트 없음) → null/null exactMatch
+- End-to-end 흐름 6단계 검증: Loader → ChatRoomFactory → sendPrompt → extractActionQueue → Validator → TestResult
+
+### Notes
+- 더 의미있는 정합성 검증은 실제 브라우저 + `/collect` 흐름으로 새 시나리오 캡처 후 가능 (action_queue 값 발생 시)
+- LLM 비결정성 때문에 IT 테스트 assertion 은 약화: ERROR_RUNTIME 만 fail, FAIL 은 허용 (diff 출력 후 사용자 검토)
+
+---
 ## [0.9.5] - 2026-04-25
 
 ### Added

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.smartuxapi.ai"  // 그룹 ID 설정
-version = "0.9.5"            // 프로젝트 버전 설정
+version = "0.9.6"            // 프로젝트 버전 설정
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCaseRealLlmIT.java
+++ b/lib/src/test/java/com/smartuxapi/scenario/FullScenarioTestCaseRealLlmIT.java
@@ -1,0 +1,138 @@
+package com.smartuxapi.scenario;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import com.smartuxapi.ai.ChatRoom;
+import com.smartuxapi.ai.gemini.GeminiChatRoom;
+import com.smartuxapi.ai.openai.ResponsesChatRoom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Full Scenario 실 LLM 통합 테스트 — opt-in.
+ *
+ * <p>실행 조건 (둘 다 충족 시에만 실행):
+ * <ul>
+ *   <li>{@code OPENAI_API_KEY} 환경 변수 설정</li>
+ *   <li>{@code SCENARIO_FILE} 환경 변수에 시나리오 JSON 경로 (또는 디렉터리)</li>
+ * </ul>
+ *
+ * <p>비용 발생 — 시나리오의 turn 수만큼 LLM API 호출이 일어남.
+ *
+ * <p>실행 예 (Windows PowerShell):
+ * <pre>
+ *   $env:OPENAI_API_KEY="sk-..."
+ *   $env:SCENARIO_FILE="C:\path\to\scenarios\test-scenario-xxx.json"
+ *   .\gradlew.bat :lib:test --tests "com.smartuxapi.scenario.FullScenarioTestCaseRealLlmIT"
+ * </pre>
+ *
+ * @since lib 0.9.6
+ */
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SCENARIO_FILE", matches = ".+")
+@DisplayName("Full Scenario 실 LLM 통합 테스트 (opt-in)")
+class FullScenarioTestCaseRealLlmIT {
+
+    private static final String DEFAULT_OPENAI_MODEL = "gpt-4.1-mini";
+    private static final String DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
+
+    @Test
+    @DisplayName("SCENARIO_FILE 의 시나리오 재현 + 결과 출력")
+    void runRealLlmScenario() throws Exception {
+        String scenarioFile = System.getenv("SCENARIO_FILE");
+        Path path = Paths.get(scenarioFile);
+        assertTrue(Files.exists(path), "scenario path not found: " + scenarioFile);
+
+        List<ScenarioData> scenarios;
+        if (Files.isDirectory(path)) {
+            scenarios = ScenarioDataLoader.loadDirectory(path);
+            assertFalse(scenarios.isEmpty(), "no .json scenario in directory: " + path);
+        } else {
+            scenarios = java.util.Collections.singletonList(ScenarioDataLoader.load(path));
+        }
+
+        ChatRoomFactory factory = scenario -> createRoom(scenario);
+        FullScenarioTestCase runner = new FullScenarioTestCase(factory, true);
+
+        int totalPass = 0, totalFail = 0, totalErr = 0, totalSkip = 0, totalTurns = 0;
+        long totalElapsed = 0;
+
+        for (ScenarioData s : scenarios) {
+            String fileName = path.toFile().isDirectory()
+                    ? "(dir) sessionId=" + s.getSessionId()
+                    : path.getFileName().toString();
+            System.out.println();
+            System.out.println("===== Replay: " + fileName + " (model=" + s.getAiModel()
+                    + ", turns=" + s.turnSize() + ") =====");
+
+            ScenarioTestResult result = runner.run(s, fileName);
+            totalPass += result.passed();
+            totalFail += result.failed();
+            totalErr += result.errored();
+            totalSkip += result.skipped();
+            totalTurns += result.total();
+            totalElapsed += result.totalElapsedMs();
+
+            for (TurnTestResult t : result.getTurnResults()) {
+                System.out.printf("  Turn#%d %-7s elapsed=%dms",
+                        t.getTurnNo(), t.getStatus(), t.getElapsedMs());
+                if (t.getStatus() == TurnTestResult.Status.FAIL) {
+                    System.out.print("  diff=" + t.getValidationResult().diffCount());
+                    System.out.println();
+                    System.out.println("    expected: " + truncate(t.getExpectedActionQueue(), 200));
+                    System.out.println("    actual  : " + truncate(t.getActualActionQueue(), 200));
+                } else if (t.getStatus() == TurnTestResult.Status.ERROR_RUNTIME) {
+                    System.out.println("  err=" + t.getErrorMessage());
+                } else {
+                    System.out.println();
+                }
+            }
+            System.out.println("  -> " + result);
+        }
+
+        System.out.println();
+        System.out.println("=========================================================");
+        System.out.printf("TOTAL: %d turns, pass=%d fail=%d error=%d skip=%d, %dms%n",
+                totalTurns, totalPass, totalFail, totalErr, totalSkip, totalElapsed);
+        System.out.println("=========================================================");
+
+        assertTrue(totalTurns > 0, "no turns replayed");
+        // assertion 약화: error 가 아닌 한 통과 (FAIL 은 LLM 비결정성으로 빈번)
+        assertEquals(0, totalErr,
+                "ERROR_RUNTIME 발생 — 네트워크/API 키/요청 형식 점검 필요");
+    }
+
+    private ChatRoom createRoom(ScenarioData scenario) {
+        String model = scenario.getAiModel();
+        if (model == null || "chatgpt".equalsIgnoreCase(model) || "openai".equalsIgnoreCase(model)) {
+            String key = System.getenv("OPENAI_API_KEY");
+            if (key == null || key.isEmpty()) return null;
+            String overrideModel = System.getenv("OPENAI_MODEL");
+            return new ResponsesChatRoom(key,
+                    overrideModel != null && !overrideModel.isEmpty() ? overrideModel : DEFAULT_OPENAI_MODEL);
+        }
+        if ("gemini".equalsIgnoreCase(model)) {
+            String key = System.getenv("GEMINI_API_KEY");
+            if (key == null || key.isEmpty()) return null;
+            String overrideModel = System.getenv("GEMINI_MODEL");
+            return new GeminiChatRoom(key,
+                    overrideModel != null && !overrideModel.isEmpty() ? overrideModel : DEFAULT_GEMINI_MODEL);
+        }
+        return null;
+    }
+
+    private static String truncate(String s, int n) {
+        if (s == null) return "null";
+        return s.length() <= n ? s : s.substring(0, n) + "...";
+    }
+}


### PR DESCRIPTION
## Summary
Phase 3 (lib v0.9.5) harness 의 실 LLM end-to-end 검증을 위한 opt-in 통합 테스트 추가.

## Verified
- Phase 2 캡처 JSON (2 turn, chatgpt) 재현
- **2 PASS / 0 FAIL / 0 ERROR / 6,051ms / ~$0.002 (gpt-4.1-mini)**
- Turn #1 학습 프롬프트 PASS (3,768ms), Turn #2 \"hello\" PASS (2,283ms)
- End-to-end: Loader → ChatRoomFactory → sendPrompt → extractActionQueue → Validator → TestResult ✅

## Notes
- `@EnabledIfEnvironmentVariable` 로 opt-in — env var 미설정 시 자동 skip
- 두 턴 모두 action_queue=null/null exactMatch (Phase 2 캡처 시 UI 컨텍스트 없음)
- 더 의미있는 정합성 검증은 브라우저 + `/collect` 흐름으로 새 시나리오 캡처 후 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)