### PR TITLE
fix(ci): scenarios fixture 누락 복구 (.gitignore negation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ smuxapi-demo/src/main/resources/config.json
 # 실 환경 수집 결과물은 반복 실행 산출물이므로 커밋하지 않음.
 # Phase 3 테스트에서 의도적으로 커밋할 fixture 는 lib/src/test/resources/ 에 저장.
 **/scenarios/
+# 단, lib 의 테스트 fixture (Phase 3 ScenarioDataLoaderTest 의 classpath 리소스) 는 예외.
+!lib/src/test/resources/scenarios/
+!lib/src/test/resources/scenarios/**

--- a/lib/src/test/resources/scenarios/sample-2turn.json
+++ b/lib/src/test/resources/scenarios/sample-2turn.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion" : 1,
+  "sessionId" : "fixture-2turn",
+  "aiModel" : "chatgpt",
+  "savedAt" : "2026-04-25T12:00:00+09:00",
+  "turnCount" : 2,
+  "turns" : [ {
+    "turnNo" : 1,
+    "uiInfo" : "{\"buttons\":[\"order\",\"cancel\"]}",
+    "userPrompt" : "주문하기 눌러줘",
+    "apiPrompt" : "UI: {ui} / User: {userMsg}",
+    "resMsg" : "주문 버튼을 클릭합니다.",
+    "actionQueue" : {
+      "actions": [
+        { "type": "click", "target": "order" }
+      ]
+    }
+  }, {
+    "turnNo" : 2,
+    "uiInfo" : null,
+    "userPrompt" : "취소",
+    "apiPrompt" : null,
+    "resMsg" : "취소 합니다.",
+    "actionQueue" : {
+      "actions": [
+        { "type": "click", "target": "cancel" }
+      ]
+    }
+  } ]
+}


### PR DESCRIPTION
## Cause
`.gitignore` 의 `**/scenarios/` 패턴이 demo 출력 디렉터리뿐 아니라 lib 테스트 fixture 까지 잡아
v0.9.5 commit 에 `lib/src/test/resources/scenarios/sample-2turn.json` (727B) 가 누락. CI Java 17/21
매트릭스에서 `ScenarioDataLoaderTest.testLoadFromClasspath` 등이 IOException 으로 실패.

## Fix
- negation 추가:
  - `!lib/src/test/resources/scenarios/`
  - `!lib/src/test/resources/scenarios/**`
- `sample-2turn.json` 추적 시작

## Test plan
- [x] `git check-ignore -v` 결과 `!lib/src/test/resources/scenarios/**` 매치 (예외 처리)
- [ ] CI Java 17/21 매트릭스 통과 (이 PR merge 후 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)